### PR TITLE
One block layout with sidenav

### DIFF
--- a/packages/strapi-icons/package.json
+++ b/packages/strapi-icons/package.json
@@ -21,9 +21,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },
-  "dependencies": {
-    "jest-styled-components": "^7.0.4"
-  },
   "scripts": {
     "analyze:bundle": "cross-env BUNDLE_ANALYZE=1 webpack",
     "build": "yarn generate:icons && webpack &&  node ../../tools/copy-files.js",

--- a/packages/strapi-parts/src/OneBlockLayout/OneBlockLayout.js
+++ b/packages/strapi-parts/src/OneBlockLayout/OneBlockLayout.js
@@ -4,6 +4,10 @@ import { Box } from '../Box';
 import { Row } from '../Row';
 import styled from 'styled-components';
 
+const FlexBox = styled(Box)`
+  flex: 1;
+`;
+
 const BlockActions = styled(Row)`
   & > * + * {
     margin-left: ${({ theme }) => theme.spaces[2]};
@@ -12,36 +16,41 @@ const BlockActions = styled(Row)`
   margin-left: ${({ pullRight }) => (pullRight ? 'auto' : undefined)};
 `;
 
-export const OneBlockLayout = ({ startActions, endActions, header, children }) => {
+export const OneBlockLayout = ({ startActions, sideNav, endActions, header, children }) => {
   return (
-    <Box>
-      {header}
-      <Box paddingLeft={10} paddingRight={10}>
-        {startActions || endActions ? (
-          <Box paddingBottom={4}>
-            <Row justifyContent="space-between">
-              {startActions && <BlockActions>{startActions}</BlockActions>}
-              {endActions && <BlockActions pullRight>{endActions}</BlockActions>}
-            </Row>
-          </Box>
-        ) : null}
+    <Row alignItems="flex-start">
+      {sideNav}
+      <FlexBox>
+        {header}
+        <Box paddingLeft={10} paddingRight={10}>
+          {startActions || endActions ? (
+            <Box paddingBottom={4}>
+              <Row justifyContent="space-between">
+                {startActions && <BlockActions>{startActions}</BlockActions>}
+                {endActions && <BlockActions pullRight>{endActions}</BlockActions>}
+              </Row>
+            </Box>
+          ) : null}
 
-        <Box hasRadius background="neutral0" shadow="tableShadow">
-          {children}
+          <Box hasRadius background="neutral0" shadow="tableShadow">
+            {children}
+          </Box>
         </Box>
-      </Box>
-    </Box>
+      </FlexBox>
+    </Row>
   );
 };
 
 OneBlockLayout.defaultProps = {
   endActions: undefined,
   startActions: undefined,
+  sideNav: undefined,
 };
 
 OneBlockLayout.propTypes = {
   children: PropTypes.node.isRequired,
   endActions: PropTypes.node,
   header: PropTypes.node.isRequired,
+  sideNav: PropTypes.node,
   startActions: PropTypes.node,
 };

--- a/packages/strapi-parts/src/OneBlockLayout/OneBlockLayout.stories.mdx
+++ b/packages/strapi-parts/src/OneBlockLayout/OneBlockLayout.stories.mdx
@@ -1,9 +1,10 @@
 <!--- OneBlockLayout.stories.mdx --->
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import BackIcon from '@strapi/icons/BackIcon';
-import EditIcon from '@strapi/icons/EditIcon';
-import AddIcon from '@strapi/icons/AddIcon';
+import { Applications, ApiTokens, AlertWarningIcon, AlertInfoIcon, AddIcon, EditIcon, BackIcon } from '@strapi/icons';
+import { MemoryRouter } from 'react-router-dom';
+import { SubNav, SubNavHeader, SubNavSection, SubNavSections, SubNavLink, SubNavLinkSection } from '../SubNav';
+import { Link } from '../Link';
 import { OneBlockLayout } from './OneBlockLayout';
 import { Box } from '../Box';
 import { Button } from '../Button';
@@ -52,5 +53,200 @@ Description...
         <Box padding={4}>hello world</Box>
       </OneBlockLayout>
     </Box>
+  </Story>
+</Canvas>
+
+## OneBlockLayout with sidenav
+
+Description...
+
+<Canvas>
+  <Story name="sidenav">
+    {() => {
+      const links = [
+        {
+          id: 1,
+          label: 'Addresses',
+          icon: <AlertWarningIcon />,
+          to: '/address',
+        },
+        {
+          id: 2,
+          label: 'Categories',
+          to: '/category',
+        },
+        {
+          id: 3,
+          label: 'Cities',
+          icon: <Applications />,
+          to: '/city',
+          active: true,
+        },
+        {
+          id: 4,
+          label: 'Countries',
+          to: '/country',
+        },
+      ];
+      return (
+        <Box background="neutral100">
+          <OneBlockLayout
+            header={
+              <HeaderLayout
+                primaryAction={<Button startIcon={<AddIcon />}>Add an entry</Button>}
+                secondaryAction={
+                  <Button variant="tertiary" startIcon={<EditIcon />}>
+                    Edit
+                  </Button>
+                }
+                title="Other CT"
+                subtitle="36 entries found"
+                as="h2"
+              />
+            }
+            sideNav={
+              <SubNav ariaLabel="Builder sub nav">
+                <SubNavHeader
+                  searchable
+                  value={''}
+                  onClear={() => {}}
+                  onChange={(e) => {}}
+                  label="Builder"
+                  searchLabel="Search..."
+                />
+                <SubNavSections>
+                  <SubNavSection label="Collection Type" collapsable badgeLabel={links.length.toString()}>
+                    {links.map((link) => (
+                      <SubNavLink to={link.to} active={link.active} key={link.id}>
+                        {link.label}
+                      </SubNavLink>
+                    ))}
+                  </SubNavSection>
+                  <Box as="li" paddingLeft={7}>
+                    <TextButton startIcon={<AddIcon />}>Click on me</TextButton>
+                  </Box>
+                  <SubNavSection label="Single Type" collapsable badgeLabel={links.length.toString()}>
+                    <SubNavLinkSection label="Default">
+                      {links.map((link) => (
+                        <SubNavLink to={link.to} key={link.id}>
+                          {link.label}
+                        </SubNavLink>
+                      ))}
+                    </SubNavLinkSection>
+                  </SubNavSection>
+                  <Box as="li" paddingLeft={7}>
+                    <TextButton startIcon={<AddIcon />}>Click on me</TextButton>
+                  </Box>
+                </SubNavSections>
+              </SubNav>
+            }
+            startActions={
+              <>
+                <Button variant="tertiary">Search</Button>
+                <Button variant="tertiary">Filter</Button>
+              </>
+            }
+            endActions={
+              <>
+                <Button variant="tertiary">Settings</Button>
+              </>
+            }
+          >
+            <Box padding={4}>
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+              abcd
+              <br />
+            </Box>
+          </OneBlockLayout>
+        </Box>
+      );
+    }}
   </Story>
 </Canvas>

--- a/packages/strapi-parts/src/SubNav/SubNav.js
+++ b/packages/strapi-parts/src/SubNav/SubNav.js
@@ -3,11 +3,15 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { Grid } from '../Grid';
 
+export const subNavWidth = `${232 / 16}rem`;
+
 const SubNavWrapper = styled(Grid)`
-  width: ${232 / 16}rem;
+  width: ${subNavWidth};
   background: ${({ theme }) => theme.colors.neutral100};
   height: 100%;
-  position: relative;
+  position: sticky;
+  top: 0;
+  height: 100vh;
   overflow-y: auto;
   border-right: 1px solid ${({ theme }) => theme.colors.neutral200};
 `;

--- a/packages/strapi-parts/src/SubNav/__tests__/SubNav.spec.js
+++ b/packages/strapi-parts/src/SubNav/__tests__/SubNav.spec.js
@@ -137,7 +137,10 @@ describe('SubNav', () => {
         width: 14.5rem;
         background: #f6f6f9;
         height: 100%;
-        position: relative;
+        position: -webkit-sticky;
+        position: sticky;
+        top: 0;
+        height: 100vh;
         overflow-y: auto;
         border-right: 1px solid #dcdce4;
       }


### PR DESCRIPTION
# Sidenav in one block layout

## Description

This PR introduces a `sideNav` props on the `OneBlockLayout` component in order for plugin creator to pass a custom side nav if they need one

## Demo

Example on : [deployed story link]

## API

```diff
+ sideNav={<SomeNav />}
```

## Screen shot

<img width="1250" alt="A sidenav set on a one block layout" src="https://user-images.githubusercontent.com/3874873/127450037-180bb5d8-0aab-4cba-8bce-36ebe064b75d.png">

