### PR TITLE
GridLayout and TwoColumnLayout aware of sideNav

### DIFF
--- a/packages/strapi-parts/src/GridLayout/GridLayout.js
+++ b/packages/strapi-parts/src/GridLayout/GridLayout.js
@@ -4,6 +4,10 @@ import { Box } from '../Box';
 import { Row } from '../Row';
 import styled from 'styled-components';
 
+const FlexBox = styled(Box)`
+  flex: 1;
+`;
+
 const BlockActions = styled(Row)`
   & > * + * {
     margin-left: ${({ theme }) => theme.spaces[2]};
@@ -18,34 +22,39 @@ const GridLayoutWrapper = styled.div`
   grid-gap: ${({ theme }) => theme.spaces[4]};
 `;
 
-export const GridLayout = ({ startActions, endActions, header, children }) => {
+export const GridLayout = ({ startActions, sideNav, endActions, header, children }) => {
   return (
-    <Box>
-      {header}
-      <Box paddingLeft={10} paddingRight={10}>
-        {startActions || endActions ? (
-          <Box paddingBottom={4}>
-            <Row justifyContent="space-between">
-              {startActions && <BlockActions>{startActions}</BlockActions>}
-              {endActions && <BlockActions pullRight>{endActions}</BlockActions>}
-            </Row>
-          </Box>
-        ) : null}
+    <Row alignItems="flex-start">
+      {sideNav}
+      <FlexBox>
+        {header}
+        <Box paddingLeft={10} paddingRight={10}>
+          {startActions || endActions ? (
+            <Box paddingBottom={4}>
+              <Row justifyContent="space-between">
+                {startActions && <BlockActions>{startActions}</BlockActions>}
+                {endActions && <BlockActions pullRight>{endActions}</BlockActions>}
+              </Row>
+            </Box>
+          ) : null}
 
-        <GridLayoutWrapper>{children}</GridLayoutWrapper>
-      </Box>
-    </Box>
+          <GridLayoutWrapper>{children}</GridLayoutWrapper>
+        </Box>
+      </FlexBox>
+    </Row>
   );
 };
 
 GridLayout.defaultProps = {
   endActions: undefined,
   startActions: undefined,
+  sideNav: undefined,
 };
 
 GridLayout.propTypes = {
   children: PropTypes.node.isRequired,
   endActions: PropTypes.node,
   header: PropTypes.node.isRequired,
+  sideNav: PropTypes.node,
   startActions: PropTypes.node,
 };

--- a/packages/strapi-parts/src/GridLayout/GridLayout.stories.mdx
+++ b/packages/strapi-parts/src/GridLayout/GridLayout.stories.mdx
@@ -1,9 +1,8 @@
 <!--- GridLayout.stories.mdx --->
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import BackIcon from '@strapi/icons/BackIcon';
-import EditIcon from '@strapi/icons/EditIcon';
-import AddIcon from '@strapi/icons/AddIcon';
+import { Applications, ApiTokens, AlertWarningIcon, AlertInfoIcon, AddIcon, EditIcon, BackIcon } from '@strapi/icons';
+import { SubNav, SubNavHeader, SubNavSection, SubNavSections, SubNavLink, SubNavLinkSection } from '../SubNav';
 import { GridLayout } from './GridLayout';
 import { Box } from '../Box';
 import { Button } from '../Button';
@@ -58,5 +57,109 @@ Description...
           ))}
       </GridLayout>
     </Box>
+  </Story>
+</Canvas>
+
+## GridLayout sideNav
+
+Description...
+
+<Canvas>
+  <Story name="sideNav">
+    {() => {
+      const links = [
+        {
+          id: 1,
+          label: 'Addresses',
+          icon: <AlertWarningIcon />,
+          to: '/address',
+        },
+        {
+          id: 2,
+          label: 'Categories',
+          to: '/category',
+        },
+        {
+          id: 3,
+          label: 'Cities',
+          icon: <Applications />,
+          to: '/city',
+          active: true,
+        },
+        {
+          id: 4,
+          label: 'Countries',
+          to: '/country',
+        },
+      ];
+      return (
+        <Box background="neutral100">
+          <GridLayout
+            header={
+              <HeaderLayout
+                primaryAction={<Button startIcon={<AddIcon />}>Add an entry</Button>}
+                secondaryAction={
+                  <Button variant="tertiary" startIcon={<EditIcon />}>
+                    Edit
+                  </Button>
+                }
+                title="Other CT"
+                subtitle="36 entries found"
+                as="h2"
+              />
+            }
+            startActions={
+              <>
+                <Button variant="tertiary">Search</Button>
+                <Button variant="tertiary">Filter</Button>
+              </>
+            }
+            endActions={
+              <>
+                <Button variant="tertiary">Settings</Button>
+              </>
+            }
+            sideNav={
+              <SubNav ariaLabel="Builder sub nav">
+                <SubNavHeader
+                  searchable
+                  value={''}
+                  onClear={() => {}}
+                  onChange={(e) => {}}
+                  label="Builder"
+                  searchLabel="Search..."
+                />
+                <SubNavSections>
+                  <SubNavSection label="Collection Type" collapsable badgeLabel={links.length.toString()}>
+                    {links.map((link) => (
+                      <SubNavLink to={link.to} active={link.active} key={link.id}>
+                        {link.label}
+                      </SubNavLink>
+                    ))}
+                  </SubNavSection>
+                  <SubNavSection label="Single Type" collapsable badgeLabel={links.length.toString()}>
+                    <SubNavLinkSection label="Default">
+                      {links.map((link) => (
+                        <SubNavLink to={link.to} key={link.id}>
+                          {link.label}
+                        </SubNavLink>
+                      ))}
+                    </SubNavLinkSection>
+                  </SubNavSection>
+                </SubNavSections>
+              </SubNav>
+            }
+          >
+            {Array(12)
+              .fill(null)
+              .map((_, idx) => (
+                <Box padding={4} hasRadius background="neutral0" padding={4} key={`box-${idx}`} shadow="tableShadow">
+                  hello world
+                </Box>
+              ))}
+          </GridLayout>
+        </Box>
+      );
+    }}
   </Story>
 </Canvas>

--- a/packages/strapi-parts/src/TwoColsLayout/TwoColsLayout.js
+++ b/packages/strapi-parts/src/TwoColsLayout/TwoColsLayout.js
@@ -5,6 +5,10 @@ import { Row } from '../Row';
 import { Grid, GridItem } from '../Grid';
 import styled from 'styled-components';
 
+const FlexBox = styled(Box)`
+  flex: 1;
+`;
+
 const BlockActions = styled(Row)`
   & > * + * {
     margin-left: ${({ theme }) => theme.spaces[2]};
@@ -13,46 +17,51 @@ const BlockActions = styled(Row)`
   margin-left: ${({ pullRight }) => (pullRight ? 'auto' : undefined)};
 `;
 
-export const TwoColsLayout = ({ startActions, endActions, header, startCol, endCol }) => {
+export const TwoColsLayout = ({ startActions, sideNav, endActions, header, startCol, endCol }) => {
   return (
-    <Box>
-      {header}
-      <Box paddingLeft={10} paddingRight={10}>
-        {startActions || endActions ? (
-          <Box paddingBottom={4}>
-            <Row justifyContent="space-between">
-              {startActions && <BlockActions>{startActions}</BlockActions>}
-              {endActions && <BlockActions pullRight>{endActions}</BlockActions>}
-            </Row>
-          </Box>
-        ) : null}
+    <Row alignItems="flex-start">
+      {sideNav}
+      <FlexBox>
+        {header}
+        <Box paddingLeft={10} paddingRight={10}>
+          {startActions || endActions ? (
+            <Box paddingBottom={4}>
+              <Row justifyContent="space-between">
+                {startActions && <BlockActions>{startActions}</BlockActions>}
+                {endActions && <BlockActions pullRight>{endActions}</BlockActions>}
+              </Row>
+            </Box>
+          ) : null}
 
-        <Grid gap={4}>
-          <GridItem col={9} s={12}>
-            <Box hasRadius background="neutral0" shadow="tableShadow">
-              {startCol}
-            </Box>
-          </GridItem>
-          <GridItem col={3} s={12}>
-            <Box hasRadius background="neutral0" shadow="tableShadow">
-              {endCol}
-            </Box>
-          </GridItem>
-        </Grid>
-      </Box>
-    </Box>
+          <Grid gap={4}>
+            <GridItem col={9} s={12}>
+              <Box hasRadius background="neutral0" shadow="tableShadow">
+                {startCol}
+              </Box>
+            </GridItem>
+            <GridItem col={3} s={12}>
+              <Box hasRadius background="neutral0" shadow="tableShadow">
+                {endCol}
+              </Box>
+            </GridItem>
+          </Grid>
+        </Box>
+      </FlexBox>
+    </Row>
   );
 };
 
 TwoColsLayout.defaultProps = {
   endActions: undefined,
   startActions: undefined,
+  sideNav: undefined,
 };
 
 TwoColsLayout.propTypes = {
   endActions: PropTypes.node,
   endCol: PropTypes.node,
   header: PropTypes.node.isRequired,
+  sideNav: PropTypes.node,
   startActions: PropTypes.node,
   startCol: PropTypes.node.isRequired,
 };

--- a/packages/strapi-parts/src/TwoColsLayout/TwoColsLayout.stories.mdx
+++ b/packages/strapi-parts/src/TwoColsLayout/TwoColsLayout.stories.mdx
@@ -1,9 +1,8 @@
 <!--- TwoColsLayout.stories.mdx --->
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import BackIcon from '@strapi/icons/BackIcon';
-import EditIcon from '@strapi/icons/EditIcon';
-import AddIcon from '@strapi/icons/AddIcon';
+import { Applications, ApiTokens, AlertWarningIcon, AlertInfoIcon, AddIcon, EditIcon, BackIcon } from '@strapi/icons';
+import { SubNav, SubNavHeader, SubNavSection, SubNavSections, SubNavLink, SubNavLinkSection } from '../SubNav';
 import { TwoColsLayout } from './TwoColsLayout';
 import { Box } from '../Box';
 import { Button } from '../Button';
@@ -52,5 +51,103 @@ Description...
         endCol={<Box padding={4}>Hello world</Box>}
       />
     </Box>
+  </Story>
+</Canvas>
+
+## TwoColsLayout sideNav
+
+Description...
+
+<Canvas>
+  <Story name="sideNav">
+    {() => {
+      const links = [
+        {
+          id: 1,
+          label: 'Addresses',
+          icon: <AlertWarningIcon />,
+          to: '/address',
+        },
+        {
+          id: 2,
+          label: 'Categories',
+          to: '/category',
+        },
+        {
+          id: 3,
+          label: 'Cities',
+          icon: <Applications />,
+          to: '/city',
+          active: true,
+        },
+        {
+          id: 4,
+          label: 'Countries',
+          to: '/country',
+        },
+      ];
+      return (
+        <Box background="neutral100">
+          <TwoColsLayout
+            header={
+              <HeaderLayout
+                primaryAction={<Button startIcon={<AddIcon />}>Add an entry</Button>}
+                secondaryAction={
+                  <Button variant="tertiary" startIcon={<EditIcon />}>
+                    Edit
+                  </Button>
+                }
+                title="Other CT"
+                subtitle="36 entries found"
+                as="h2"
+              />
+            }
+            startActions={
+              <>
+                <Button variant="tertiary">Search</Button>
+                <Button variant="tertiary">Filter</Button>
+              </>
+            }
+            endActions={
+              <>
+                <Button variant="tertiary">Settings</Button>
+              </>
+            }
+            startCol={<Box padding={4}>Hello world</Box>}
+            endCol={<Box padding={4}>Hello world</Box>}
+            sideNav={
+              <SubNav ariaLabel="Builder sub nav">
+                <SubNavHeader
+                  searchable
+                  value={''}
+                  onClear={() => {}}
+                  onChange={(e) => {}}
+                  label="Builder"
+                  searchLabel="Search..."
+                />
+                <SubNavSections>
+                  <SubNavSection label="Collection Type" collapsable badgeLabel={links.length.toString()}>
+                    {links.map((link) => (
+                      <SubNavLink to={link.to} active={link.active} key={link.id}>
+                        {link.label}
+                      </SubNavLink>
+                    ))}
+                  </SubNavSection>
+                  <SubNavSection label="Single Type" collapsable badgeLabel={links.length.toString()}>
+                    <SubNavLinkSection label="Default">
+                      {links.map((link) => (
+                        <SubNavLink to={link.to} key={link.id}>
+                          {link.label}
+                        </SubNavLink>
+                      ))}
+                    </SubNavLinkSection>
+                  </SubNavSection>
+                </SubNavSections>
+              </SubNav>
+            }
+          />
+        </Box>
+      );
+    }}
   </Story>
 </Canvas>


### PR DESCRIPTION


## Description

Adds a `sideNav` prop to the `GridLayout` and `TwoColumnLayout`


## API

```diff
+ sideNav={<SideNav />}
```

## Screenshots

<img width="1249" alt="Screenshot 2021-07-29 at 11 40 09" src="https://user-images.githubusercontent.com/3874873/127469689-1fdcbcb6-5ac2-4756-8ebd-3f440442ad9a.png">
<img width="1249" alt="Screenshot 2021-07-29 at 11 40 22" src="https://user-images.githubusercontent.com/3874873/127469698-d53ffa60-6f7c-4a88-adc3-32a2866bc8c2.png">
