### PR TITLE
Fix broken UI

### DIFF
--- a/example/src/layouts/AppLayout.js
+++ b/example/src/layouts/AppLayout.js
@@ -7,13 +7,9 @@ export const AppLayout = ({ children, subNav }) => {
     <Box background="neutral100">
       <SkipToContent>Skip to main content</SkipToContent>
       <Row alignItems="flex-start">
-        <Box style={{ height: "100vh" }}>
-          <SideNav />
-        </Box>
-
-        <Box style={{ height: "100vh" }}>{subNav}</Box>
-
-        <Box style={{ flex: 1, overflow: "hidden" }}>{children}</Box>
+        <SideNav />
+        {subNav}
+        <Box style={{ flex: 1 }}>{children}</Box>
       </Row>
     </Box>
   );

--- a/packages/strapi-parts/src/Card/CardAsset.js
+++ b/packages/strapi-parts/src/Card/CardAsset.js
@@ -8,7 +8,8 @@ const CardAssetImg = styled.img`
   // addition infos: https://stackoverflow.com/questions/5804256/image-inside-div-has-extra-space-below-the-image
   margin: 0;
   padding: 0;
-  height: 100%;
+  max-height: 100%;
+  max-width: 100%;
 `;
 
 const CardAssetSizes = {

--- a/packages/strapi-parts/src/Card/__tests__/Card.spec.js
+++ b/packages/strapi-parts/src/Card/__tests__/Card.spec.js
@@ -184,7 +184,8 @@ describe('Card', () => {
       .c7 {
         margin: 0;
         padding: 0;
-        height: 100%;
+        max-height: 100%;
+        max-width: 100%;
       }
 
       .c6 {

--- a/packages/strapi-parts/src/GridLayout/GridLayout.js
+++ b/packages/strapi-parts/src/GridLayout/GridLayout.js
@@ -4,10 +4,14 @@ import { Box } from '../Box';
 import { Row } from '../Row';
 import styled from 'styled-components';
 
-const FlexBox = styled(Box)`
-  flex: 1;
+const GridContainer = styled(Box)`
+  display: grid;
+  grid-template-columns: ${({ hasSideNav }) => (hasSideNav ? `auto 1fr` : '1fr')};
 `;
 
+const OverflowingItem = styled(Box)`
+  overflow: auto;
+`;
 const BlockActions = styled(Row)`
   & > * + * {
     margin-left: ${({ theme }) => theme.spaces[2]};
@@ -24,9 +28,9 @@ const GridLayoutWrapper = styled.div`
 
 export const GridLayout = ({ startActions, sideNav, endActions, header, children }) => {
   return (
-    <Row alignItems="flex-start">
+    <GridContainer hasSideNav={Boolean(sideNav)}>
       {sideNav}
-      <FlexBox>
+      <OverflowingItem paddingBottom={10}>
         {header}
         <Box paddingLeft={10} paddingRight={10}>
           {startActions || endActions ? (
@@ -40,8 +44,8 @@ export const GridLayout = ({ startActions, sideNav, endActions, header, children
 
           <GridLayoutWrapper>{children}</GridLayoutWrapper>
         </Box>
-      </FlexBox>
-    </Row>
+      </OverflowingItem>
+    </GridContainer>
   );
 };
 

--- a/packages/strapi-parts/src/MainNav/MainNav.js
+++ b/packages/strapi-parts/src/MainNav/MainNav.js
@@ -7,8 +7,10 @@ import { MainNavContext } from './MainNavContext';
 const MainNavWrapper = styled(Grid)`
   width: ${({ condensed }) => (condensed ? 'max-content' : `${224 / 16}rem`)};
   background: ${({ theme }) => theme.colors.neutral0};
-  height: 100%;
-  position: relative;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  z-index: 2;
 `;
 
 export const MainNav = ({ condensed, ...props }) => {

--- a/packages/strapi-parts/src/MainNav/__tests__/MainNav.spec.js
+++ b/packages/strapi-parts/src/MainNav/__tests__/MainNav.spec.js
@@ -106,8 +106,11 @@ describe('MainNav', () => {
       .c0 {
         width: 14rem;
         background: #ffffff;
-        height: 100%;
-        position: relative;
+        position: -webkit-sticky;
+        position: sticky;
+        top: 0;
+        height: 100vh;
+        z-index: 2;
       }
 
       .c6 {
@@ -613,8 +616,11 @@ describe('MainNav', () => {
         width: -moz-max-content;
         width: max-content;
         background: #ffffff;
-        height: 100%;
-        position: relative;
+        position: -webkit-sticky;
+        position: sticky;
+        top: 0;
+        height: 100vh;
+        z-index: 2;
       }
 
       .c8 > * {

--- a/packages/strapi-parts/src/OneBlockLayout/OneBlockLayout.js
+++ b/packages/strapi-parts/src/OneBlockLayout/OneBlockLayout.js
@@ -4,8 +4,13 @@ import { Box } from '../Box';
 import { Row } from '../Row';
 import styled from 'styled-components';
 
-const FlexBox = styled(Box)`
-  flex: 1;
+const GridContainer = styled(Box)`
+  display: grid;
+  grid-template-columns: ${({ hasSideNav }) => (hasSideNav ? `auto 1fr` : '1fr')};
+`;
+
+const OverflowingItem = styled(Box)`
+  overflow: auto;
 `;
 
 const BlockActions = styled(Row)`
@@ -18,9 +23,9 @@ const BlockActions = styled(Row)`
 
 export const OneBlockLayout = ({ startActions, sideNav, endActions, header, children }) => {
   return (
-    <Row alignItems="flex-start">
+    <GridContainer hasSideNav={Boolean(sideNav)}>
       {sideNav}
-      <FlexBox>
+      <OverflowingItem paddingBottom={10}>
         {header}
         <Box paddingLeft={10} paddingRight={10}>
           {startActions || endActions ? (
@@ -36,8 +41,8 @@ export const OneBlockLayout = ({ startActions, sideNav, endActions, header, chil
             {children}
           </Box>
         </Box>
-      </FlexBox>
-    </Row>
+      </OverflowingItem>
+    </GridContainer>
   );
 };
 

--- a/packages/strapi-parts/src/OneBlockLayout/OneBlockLayout.stories.mdx
+++ b/packages/strapi-parts/src/OneBlockLayout/OneBlockLayout.stories.mdx
@@ -2,6 +2,7 @@
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Applications, ApiTokens, AlertWarningIcon, AlertInfoIcon, AddIcon, EditIcon, BackIcon } from '@strapi/icons';
+import DeleteIcon from '@strapi/icons/DeleteIcon';
 import { MemoryRouter } from 'react-router-dom';
 import { SubNav, SubNavHeader, SubNavSection, SubNavSections, SubNavLink, SubNavLinkSection } from '../SubNav';
 import { Link } from '../Link';
@@ -10,6 +11,10 @@ import { Box } from '../Box';
 import { Button } from '../Button';
 import { HeaderLayout } from '../HeaderLayout';
 import { Row } from '../Row';
+import { Table, Thead, Tbody, Tr, Td, Th, TFooter } from '../Table';
+import { TableLabel, Text } from '../Text';
+import { BaseCheckbox } from '../BaseCheckbox';
+import { IconButton } from '../IconButton';
 
 <Meta title="Design System/Layouts/OneBlockLayout" component={OneBlockLayout} />
 
@@ -88,6 +93,18 @@ Description...
           to: '/country',
         },
       ];
+      const ROW_COUNT = 6;
+      const COL_COUNT = 10;
+      const entry = {
+        cover: 'https://avatars.githubusercontent.com/u/3874873?v=4',
+        description: 'Chez Léon is a human sized Parisian',
+        category: 'French cuisine',
+        contact: 'Leon Lafrite',
+      };
+      const entries = [];
+      for (let i = 0; i < 5; i++) {
+        entries.push({ ...entry, id: i });
+      }
       return (
         <Box background="neutral100">
           <OneBlockLayout
@@ -122,9 +139,6 @@ Description...
                       </SubNavLink>
                     ))}
                   </SubNavSection>
-                  <Box as="li" paddingLeft={7}>
-                    <TextButton startIcon={<AddIcon />}>Click on me</TextButton>
-                  </Box>
                   <SubNavSection label="Single Type" collapsable badgeLabel={links.length.toString()}>
                     <SubNavLinkSection label="Default">
                       {links.map((link) => (
@@ -134,9 +148,6 @@ Description...
                       ))}
                     </SubNavLinkSection>
                   </SubNavSection>
-                  <Box as="li" paddingLeft={7}>
-                    <TextButton startIcon={<AddIcon />}>Click on me</TextButton>
-                  </Box>
                 </SubNavSections>
               </SubNav>
             }
@@ -152,98 +163,81 @@ Description...
               </>
             }
           >
-            <Box padding={4}>
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-              abcd
-              <br />
-            </Box>
+            <Table
+              colCount={COL_COUNT}
+              rowCount={ROW_COUNT}
+              footer={<TFooter icon={<AddIcon />}>Add another field to this collection type</TFooter>}
+            >
+              <Thead>
+                <Tr>
+                  <Th>
+                    <BaseCheckbox aria-label="Select all entries" />
+                  </Th>
+                  <Th>
+                    <TableLabel>ID</TableLabel>
+                  </Th>
+                  <Th>
+                    <TableLabel>Cover</TableLabel>
+                  </Th>
+                  <Th>
+                    <TableLabel>Description</TableLabel>
+                  </Th>
+                  <Th>
+                    <TableLabel>Categories</TableLabel>
+                  </Th>
+                  <Th>
+                    <TableLabel>Contact</TableLabel>
+                  </Th>
+                  <Th>More</Th>
+                  <Th>More</Th>
+                  <Th>More</Th>
+                  <Th>
+                    <VisuallyHidden>Actions</VisuallyHidden>
+                  </Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {entries.map((entry) => (
+                  <Tr key={entry.id}>
+                    <Td>
+                      <BaseCheckbox aria-label={`Select ${entry.contact}`} />
+                    </Td>
+                    <Td>
+                      <Text textColor="neutral800">{entry.id}</Text>
+                    </Td>
+                    <Td>
+                      <Avatar src={entry.cover} alt={entry.contact} />
+                    </Td>
+                    <Td>
+                      <Text textColor="neutral800">{entry.description}</Text>
+                    </Td>
+                    <Td>
+                      <Text textColor="neutral800">{entry.category}</Text>
+                    </Td>
+                    <Td>
+                      <Text textColor="neutral800">{entry.contact}</Text>
+                    </Td>
+                    <Td>
+                      <Text textColor="neutral800">{entry.description}</Text>
+                    </Td>
+                    <Td>
+                      <Text textColor="neutral800">{entry.description}</Text>
+                    </Td>
+                    <Td>
+                      <Text textColor="neutral800">{entry.description}</Text>
+                    </Td>
+                    <Td>
+                      <Row>
+                        <IconButton onClick={() => console.log('edit')} label="Edit" icon={<EditIcon />} />
+                        <Box paddingLeft={1}>
+                          <IconButton onClick={() => console.log('edit')} label="Delete" icon={<DeleteIcon />} />
+                        </Box>
+                      </Row>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
           </OneBlockLayout>
         </Box>
       );

--- a/packages/strapi-parts/src/SubNav/SubNav.js
+++ b/packages/strapi-parts/src/SubNav/SubNav.js
@@ -8,12 +8,12 @@ export const subNavWidth = `${232 / 16}rem`;
 const SubNavWrapper = styled(Grid)`
   width: ${subNavWidth};
   background: ${({ theme }) => theme.colors.neutral100};
-  height: 100%;
   position: sticky;
   top: 0;
   height: 100vh;
   overflow-y: auto;
   border-right: 1px solid ${({ theme }) => theme.colors.neutral200};
+  z-index: 1;
 `;
 
 export const SubNav = ({ ariaLabel, ...props }) => {

--- a/packages/strapi-parts/src/SubNav/__tests__/SubNav.spec.js
+++ b/packages/strapi-parts/src/SubNav/__tests__/SubNav.spec.js
@@ -136,13 +136,13 @@ describe('SubNav', () => {
       .c0 {
         width: 14.5rem;
         background: #f6f6f9;
-        height: 100%;
         position: -webkit-sticky;
         position: sticky;
         top: 0;
         height: 100vh;
         overflow-y: auto;
         border-right: 1px solid #dcdce4;
+        z-index: 1;
       }
 
       .c11 > * {

--- a/packages/strapi-parts/src/TwoColsLayout/TwoColsLayout.js
+++ b/packages/strapi-parts/src/TwoColsLayout/TwoColsLayout.js
@@ -5,8 +5,13 @@ import { Row } from '../Row';
 import { Grid, GridItem } from '../Grid';
 import styled from 'styled-components';
 
-const FlexBox = styled(Box)`
-  flex: 1;
+const GridContainer = styled(Box)`
+  display: grid;
+  grid-template-columns: ${({ hasSideNav }) => (hasSideNav ? `auto 1fr` : '1fr')};
+`;
+
+const OverflowingItem = styled(Box)`
+  overflow: auto;
 `;
 
 const BlockActions = styled(Row)`
@@ -19,9 +24,9 @@ const BlockActions = styled(Row)`
 
 export const TwoColsLayout = ({ startActions, sideNav, endActions, header, startCol, endCol }) => {
   return (
-    <Row alignItems="flex-start">
+    <GridContainer hasSideNav={Boolean(sideNav)}>
       {sideNav}
-      <FlexBox>
+      <OverflowingItem paddingBottom={10}>
         {header}
         <Box paddingLeft={10} paddingRight={10}>
           {startActions || endActions ? (
@@ -46,8 +51,8 @@ export const TwoColsLayout = ({ startActions, sideNav, endActions, header, start
             </GridItem>
           </Grid>
         </Box>
-      </FlexBox>
-    </Row>
+      </OverflowingItem>
+    </GridContainer>
   );
 };
 


### PR DESCRIPTION
- Fix the main nav position sticky issue
- Make sure the table is scrollable in the different layouts
- Fixing the card asset that was overflowing outside the card in the grid layout

To test, make sure to start the example app with the local version of parts and navigate in the different pages (settings and media libs)