### PR TITLE
Add a function to extend a theme

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.1.1",
-    "@strapi/parts": "*",
-    "@strapi/icons": "*",
+    "@strapi/parts": "file:../packages/strapi-parts/dist",
+    "@strapi/icons": "file:../packages/strapi-icons/dist",
     "codemirror": "^5.62.2",
     "highlight.js": "^11.1.0",
     "jest-styled-components": "^7.0.4",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1575,15 +1575,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@strapi/icons@*":
-  version "0.0.1-alpha.4"
-  resolved "https://registry.yarnpkg.com/@strapi/icons/-/icons-0.0.1-alpha.4.tgz#f3e66f05b8aa0ae1615380e68cc0125fe405777e"
-  integrity sha512-Lnfam0vCD2PWNdvnyG9ZHtvTKgDdSc7AvqzqlxC3BlbvrNBMov3XtvCZFfW1TgXZ4iwGbCmuN+JDmiFtiAWygA==
+"@strapi/icons@file:../packages/strapi-icons/dist":
+  version "0.0.1-alpha.2"
 
-"@strapi/parts@*":
-  version "0.0.1-alpha.4"
-  resolved "https://registry.yarnpkg.com/@strapi/parts/-/parts-0.0.1-alpha.4.tgz#ffeeb856d2e4b0b6f5ae84f28e071e73e1c3d07e"
-  integrity sha512-1LBipdmZiCEdO6RC+YSsVEkHV3XxStTFxTKPz3bsorb5Rt52FchOB2CkHTjIK4+WmNvHdDJh1b98ZC0M0gJCEQ==
+"@strapi/parts@file:../packages/strapi-parts/dist":
+  version "0.0.1-alpha.2"
   dependencies:
     compute-scroll-into-view "^1.0.17"
     prop-types "^15.7.2"

--- a/packages/strapi-parts/src/themes/__tests__/extendTheme.spec.js
+++ b/packages/strapi-parts/src/themes/__tests__/extendTheme.spec.js
@@ -1,0 +1,111 @@
+import { extendTheme } from '../extendTheme';
+import { lightTheme } from '../light-theme';
+
+Object.freeze(lightTheme);
+
+describe('extendTheme', () => {
+  it('throws an error when passing an invalid value for the first argument', () => {
+    let error;
+
+    try {
+      extendTheme(null, null);
+    } catch (e) {
+      error = e.message;
+    }
+
+    expect(error).toMatchInlineSnapshot(`
+      "
+      The first argument should be an object and corresponds to the theme you want to extend.
+
+      The following is an example:
+
+
+      import { lightTheme, extendTheme } from '@strapi/parts/themes';
+
+      const myCustomTheme = extendTheme(lightTheme, {
+          colors: /* put the overrides for the colors key */,
+      shadows: /* put the overrides for the shadows key */,
+      zIndices: /* put the overrides for the zIndices key */,
+      spaces: /* put the overrides for the spaces key */,
+      borderRadius: /* put the overrides for the borderRadius key */,
+      mediaQueries: /* put the overrides for the mediaQueries key */,
+      })
+      "
+    `);
+  });
+
+  it('throws an error when passing an invalid value for the second argument', () => {
+    let error;
+
+    try {
+      extendTheme(lightTheme, null);
+    } catch (e) {
+      error = e.message;
+    }
+
+    expect(error).toMatchInlineSnapshot(`
+      "
+      The second argument should be an object and corresponds to the keys of the theme you want to override.
+
+      The following is an example:
+
+
+      import { lightTheme, extendTheme } from '@strapi/parts/themes';
+
+      const myCustomTheme = extendTheme(lightTheme, {
+          colors: /* put the overrides for the colors key */,
+      shadows: /* put the overrides for the shadows key */,
+      zIndices: /* put the overrides for the zIndices key */,
+      spaces: /* put the overrides for the spaces key */,
+      borderRadius: /* put the overrides for the borderRadius key */,
+      mediaQueries: /* put the overrides for the mediaQueries key */,
+      })
+      "
+    `);
+  });
+
+  it('overrides the given color', () => {
+    const myTheme = extendTheme(lightTheme, {
+      colors: {
+        primary100: 'red',
+      },
+    });
+
+    const expectedColors = { ...lightTheme.colors, primary100: 'red' };
+
+    expect(myTheme).toEqual({
+      ...lightTheme,
+      colors: expectedColors,
+    });
+    expect(lightTheme.colors.primary100).toMatchInlineSnapshot(`"#f0f0ff"`);
+  });
+
+  it('overrides a spacing value color', () => {
+    const myTheme = extendTheme(lightTheme, {
+      spaces: [1, 2, 3],
+    });
+
+    const expectedSpaces = [1, 2, 3];
+    expect(myTheme).toEqual({
+      ...lightTheme,
+      spaces: expectedSpaces,
+    });
+
+    expect(lightTheme.spaces).toMatchInlineSnapshot(`
+      Array [
+        "0px",
+        "4px",
+        "8px",
+        "12px",
+        "16px",
+        "20px",
+        "24px",
+        "32px",
+        "40px",
+        "48px",
+        "56px",
+        "64px",
+      ]
+    `);
+  });
+});

--- a/packages/strapi-parts/src/themes/extendTheme.js
+++ b/packages/strapi-parts/src/themes/extendTheme.js
@@ -1,0 +1,60 @@
+import { lightTheme } from './light-theme';
+
+const generateError = (customMessage) => `
+${customMessage}
+
+The following is an example:
+
+
+import { lightTheme, extendTheme } from '@strapi/parts/themes';
+
+const myCustomTheme = extendTheme(lightTheme, {
+    ${Object.keys(lightTheme)
+      .map((key) => `${key}: /* put the overrides for the ${key} key */,`)
+      .join('\n')}
+})
+`;
+
+const isObject = (item) => {
+  return item && typeof item === 'object' && !Array.isArray(item);
+};
+
+const mergeDeep = (target, overrides) => {
+  const output = Object.assign({}, target);
+
+  if (isObject(target) && isObject(overrides)) {
+    Object.keys(overrides).forEach((key) => {
+      if (isObject(overrides[key])) {
+        if (target.hasOwnProperty(key)) {
+          output[key] = mergeDeep(target[key], overrides[key]);
+        } else {
+          output[key] = overrides[key];
+        }
+      } else {
+        output[key] = overrides[key];
+      }
+    });
+  }
+
+  return output;
+};
+
+export const extendTheme = (theme, overrides) => {
+  if (!isObject(theme)) {
+    const error = generateError(
+      'The first argument should be an object and corresponds to the theme you want to extend.',
+    );
+
+    throw new Error(error);
+  }
+
+  if (!isObject(overrides)) {
+    const error = generateError(
+      'The second argument should be an object and corresponds to the keys of the theme you want to override.',
+    );
+
+    throw new Error(error);
+  }
+
+  return mergeDeep(theme, overrides);
+};

--- a/packages/strapi-parts/src/themes/extendTheme.js
+++ b/packages/strapi-parts/src/themes/extendTheme.js
@@ -20,7 +20,7 @@ const isObject = (item) => {
 };
 
 const mergeDeep = (target, overrides) => {
-  const output = Object.assign({}, target);
+  const output = { ...target };
 
   if (isObject(target) && isObject(overrides)) {
     Object.keys(overrides).forEach((key) => {

--- a/packages/strapi-parts/src/themes/index.js
+++ b/packages/strapi-parts/src/themes/index.js
@@ -1,1 +1,2 @@
 export * from './light-theme';
+export * from './extendTheme';


### PR DESCRIPTION


## Description

This PR adds a function that aims to extend a theme


## API


```js
 const myTheme = extendTheme(lightTheme, {
  colors: {
    primary100: 'red',
  },
});
```

will only override the "primary100" key and only this one