### PR TITLE
Fix the focus when closing the select with a mouse

### DIFF
--- a/packages/strapi-parts/src/Select/__tests__/Select.e2e.js
+++ b/packages/strapi-parts/src/Select/__tests__/Select.e2e.js
@@ -98,7 +98,11 @@ describe('Select', () => {
 
       it('does NOT send back the focus to the select button when closing the select with a mouse', async () => {
         await page.click('#select1');
+        await expect(page).toHaveSelector('[role="listbox"]', { timeout: 1000 });
+
         await page.click('body');
+        await expect(page).not.toHaveSelector('[role="listbox"]', { timeout: 1000 });
+
         await expect(page).not.toHaveFocus('#select1');
       });
 

--- a/packages/strapi-parts/src/Select/__tests__/Select.e2e.js
+++ b/packages/strapi-parts/src/Select/__tests__/Select.e2e.js
@@ -96,6 +96,12 @@ describe('Select', () => {
         await expect(page).toHaveFocus('#select1');
       });
 
+      it('does NOT send back the focus to the select button when closing the select with a mouse', async () => {
+        await page.click('#select1');
+        await page.click('body');
+        await expect(page).not.toHaveFocus('#select1');
+      });
+
       it('changes the button content and the select value when pressing Enter on an item', async () => {
         await page.focus('#select1');
         await page.keyboard.press('ArrowUp');

--- a/packages/strapi-parts/src/Select/hooks/useButtonRef.js
+++ b/packages/strapi-parts/src/Select/hooks/useButtonRef.js
@@ -6,7 +6,7 @@ export const useButtonRef = (expanded) => {
   const mountedRef = useRef(null);
   /**
    * Allows to make sure to re-send the focus only when the last action was
-   * a triggered by a keyboard event
+   * triggered by a keyboard event
    */
   const previousState = useRef();
 

--- a/packages/strapi-parts/src/Select/hooks/useButtonRef.js
+++ b/packages/strapi-parts/src/Select/hooks/useButtonRef.js
@@ -1,14 +1,26 @@
 import { useEffect, useRef } from 'react';
+import { DownState, UpState } from '../constants';
 
 export const useButtonRef = (expanded) => {
   const buttonRef = useRef(null);
   const mountedRef = useRef(null);
+  /**
+   * Allows to make sure to re-send the focus only when the last action was
+   * a triggered by a keyboard event
+   */
+  const previousState = useRef();
+
+  if (expanded) {
+    previousState.current = expanded;
+  }
 
   useEffect(() => {
     if (!mountedRef.current) return;
     if (expanded) return;
 
-    buttonRef.current.focus();
+    if (previousState.current === DownState.Keyboard || previousState.current === UpState.Keyboard) {
+      buttonRef.current.focus();
+    }
   }, [expanded]);
 
   useEffect(() => {


### PR DESCRIPTION

## Description

Ensure to restore the focus on the select button only when it's closed using a keyboard

## Screenshots

![Opening the select with a mouse and closing it to see that the focus is not sent to the select button. Then, opening the select using the keyboard and seeing that the focus is well sent to the select button](https://user-images.githubusercontent.com/3874873/127980888-2d91b85c-5910-4b89-8cc4-8d0f7eb657e1.gif)
