### PR TITLE
Handle viewport overflow top && left for tooltip

### DIFF
--- a/packages/strapi-parts/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-parts/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -285,7 +285,6 @@ describe('ModalLayout', () => {
             />
             <p
               class="c15"
-              style="white-space: nowrap;"
             >
               Close the modal
             </p>

--- a/packages/strapi-parts/src/ModalLayout/__tests__/ModalLayout.spec.js
+++ b/packages/strapi-parts/src/ModalLayout/__tests__/ModalLayout.spec.js
@@ -285,6 +285,7 @@ describe('ModalLayout', () => {
             />
             <p
               class="c15"
+              style="white-space: nowrap;"
             >
               Close the modal
             </p>

--- a/packages/strapi-parts/src/Tooltip/Tooltip.js
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.js
@@ -41,7 +41,7 @@ export const Tooltip = ({ children, label, description, delay, position, id, ...
           {...props}
         >
           {visible && <VisuallyHidden id={descriptionId}>{description}</VisuallyHidden>}
-          <P style={{ whiteSpace: 'nowrap' }} small={true} highlighted={visible} textColor="neutral0">
+          <P small={true} highlighted={visible} textColor="neutral0">
             {label || description}
           </P>
         </TooltipWrapper>

--- a/packages/strapi-parts/src/Tooltip/Tooltip.js
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.js
@@ -41,7 +41,7 @@ export const Tooltip = ({ children, label, description, delay, position, id, ...
           {...props}
         >
           {visible && <VisuallyHidden id={descriptionId}>{description}</VisuallyHidden>}
-          <P small={true} highlighted={true} textColor="neutral0">
+          <P style={{ whiteSpace: 'nowrap' }} small={true} highlighted={visible} textColor="neutral0">
             {label || description}
           </P>
         </TooltipWrapper>

--- a/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
@@ -3,6 +3,7 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Tooltip } from './Tooltip';
 import { Box } from '../Box';
+import { Row } from '../Row';
 import { Grid, GridItem } from '../Grid';
 
 <Meta title="Design System/Molecules/Tooltip" component={Tooltip} />
@@ -147,5 +148,24 @@ Description...
     <Tooltip label="This is the label">
       <button>+</button>
     </Tooltip>
+  </Story>
+  <Story name="top-left">
+    <Tooltip label="This is the label">
+      <button>hello</button>
+    </Tooltip>
+  </Story>
+  <Story name="top-center">
+    <Row justifyContent="center">
+      <Tooltip label="This is the label">
+        <button>hello</button>
+      </Tooltip>
+    </Row>
+  </Story>
+  <Story name="top-right">
+    <Row justifyContent="flex-end">
+      <Tooltip label="This is the label">
+        <button>hello</button>
+      </Tooltip>
+    </Row>
   </Story>
 </Canvas>

--- a/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
@@ -165,9 +165,23 @@ Description...
   </Story>
   <Story name="top-right">
     <Row justifyContent="flex-end">
-      <Tooltip label="This is the label">
+      <Tooltip label="This is the label dewdewd wedewdew">
         <button>tooltip</button>
       </Tooltip>
     </Row>
+  </Story>
+  <Story name="right-center">
+    <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '200px' }}>
+      <Tooltip label="This is the label">
+        <button>tooltip</button>
+      </Tooltip>
+    </div>
+  </Story>
+  <Story name="left-center">
+    <div style={{ marginTop: '200px' }}>
+      <Tooltip label="This is the label">
+        <button>hello</button>
+      </Tooltip>
+    </div>
   </Story>
 </Canvas>

--- a/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
@@ -19,8 +19,8 @@ Description...
 <Canvas>
   <Story name="top-right">
     <Row justifyContent="flex-end">
-      <Tooltip label="This is the label">
-        <button>hello</button>
+      <Tooltip label="This is dzad zadzadzad zadzad za dza az zad az dza dazadz daz azdthe label">
+        <button>tooltip</button>
       </Tooltip>
     </Row>
   </Story>
@@ -157,9 +157,11 @@ Description...
     </Tooltip>
   </Story>
   <Story name="top-left">
-    <Tooltip label="This is the label">
-      <button>hello</button>
-    </Tooltip>
+    <div style={{ marginTop: '0px' }}>
+      <Tooltip label="This is the label">
+        <button>hello</button>
+      </Tooltip>
+    </div>
   </Story>
   <Story name="top-center">
     <Row justifyContent="center">

--- a/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
@@ -17,13 +17,6 @@ This is the doc of the `Tooltip` component
 Description...
 
 <Canvas>
-  <Story name="top-right">
-    <Row justifyContent="flex-end">
-      <Tooltip label="This is dzad zadzadzad zadzad za dza az zad az dza dazadz daz azdthe label">
-        <button>tooltip</button>
-      </Tooltip>
-    </Row>
-  </Story>
   <Story name="base">
     <div style={{ marginLeft: '400px', marginTop: '200px', width: '400px' }}>
       <p>
@@ -157,7 +150,7 @@ Description...
     </Tooltip>
   </Story>
   <Story name="top-left">
-    <div style={{ marginTop: '0px' }}>
+    <div>
       <Tooltip label="This is the label">
         <button>hello</button>
       </Tooltip>
@@ -167,6 +160,13 @@ Description...
     <Row justifyContent="center">
       <Tooltip label="This is the label">
         <button>hello</button>
+      </Tooltip>
+    </Row>
+  </Story>
+  <Story name="top-right">
+    <Row justifyContent="flex-end">
+      <Tooltip label="This is the label">
+        <button>tooltip</button>
       </Tooltip>
     </Row>
   </Story>

--- a/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
@@ -17,6 +17,13 @@ This is the doc of the `Tooltip` component
 Description...
 
 <Canvas>
+  <Story name="top-right">
+    <Row justifyContent="flex-end">
+      <Tooltip label="This is the label">
+        <button>hello</button>
+      </Tooltip>
+    </Row>
+  </Story>
   <Story name="base">
     <div style={{ marginLeft: '400px', marginTop: '200px', width: '400px' }}>
       <p>
@@ -156,13 +163,6 @@ Description...
   </Story>
   <Story name="top-center">
     <Row justifyContent="center">
-      <Tooltip label="This is the label">
-        <button>hello</button>
-      </Tooltip>
-    </Row>
-  </Story>
-  <Story name="top-right">
-    <Row justifyContent="flex-end">
       <Tooltip label="This is the label">
         <button>hello</button>
       </Tooltip>

--- a/packages/strapi-parts/src/Tooltip/__tests__/Tooltip.spec.js
+++ b/packages/strapi-parts/src/Tooltip/__tests__/Tooltip.spec.js
@@ -26,7 +26,7 @@ describe('Tooltip', () => {
       }
 
       .c2 {
-        font-weight: 500;
+        font-weight: 400;
         font-size: 0.75rem;
         line-height: 1.33;
         color: #ffffff;
@@ -58,6 +58,7 @@ describe('Tooltip', () => {
           >
             <p
               class="c2"
+              style="white-space: nowrap;"
             >
               Content of the tooltip fefe
             </p>
@@ -137,6 +138,7 @@ describe('Tooltip', () => {
             </div>
             <p
               class="c3"
+              style="white-space: nowrap;"
             >
               Content of the tooltip fefe
             </p>
@@ -214,6 +216,7 @@ describe('Tooltip', () => {
             />
             <p
               class="c3"
+              style="white-space: nowrap;"
             >
               Content of the tooltip fefe
             </p>

--- a/packages/strapi-parts/src/Tooltip/__tests__/Tooltip.spec.js
+++ b/packages/strapi-parts/src/Tooltip/__tests__/Tooltip.spec.js
@@ -58,7 +58,6 @@ describe('Tooltip', () => {
           >
             <p
               class="c2"
-              style="white-space: nowrap;"
             >
               Content of the tooltip fefe
             </p>
@@ -138,7 +137,6 @@ describe('Tooltip', () => {
             </div>
             <p
               class="c3"
-              style="white-space: nowrap;"
             >
               Content of the tooltip fefe
             </p>
@@ -216,7 +214,6 @@ describe('Tooltip', () => {
             />
             <p
               class="c3"
-              style="white-space: nowrap;"
             >
               Content of the tooltip fefe
             </p>

--- a/packages/strapi-parts/src/Tooltip/utils/__tests__/positionTooltip.spec.js
+++ b/packages/strapi-parts/src/Tooltip/utils/__tests__/positionTooltip.spec.js
@@ -38,4 +38,77 @@ describe('positionTooltip', () => {
 
     expect(position).toEqual({ left: 608, top: 1095 });
   });
+
+  it('positions the tooltip on the right of the toggle source when toggle source pos is top-left', () => {
+    toggleSourceNode = {
+      getBoundingClientRect: () => ({ left: 15, top: 15, width: 50, height: 20 }),
+    };
+    window.pageYOffset = 0;
+
+    const position = positionTooltip(tooltipNode, toggleSourceNode);
+
+    expect(position).toEqual({ left: 73, top: 3 });
+  });
+
+  it('positions the tooltip on the right of the toggle source when toggle source pos is bottom-left', () => {
+    toggleSourceNode = {
+      getBoundingClientRect: () => ({ left: 15, top: 760, width: 50, height: 20 }),
+    };
+
+    window.pageYOffset = 0;
+    window.innerHeight = 800;
+
+    const position = positionTooltip(tooltipNode, toggleSourceNode);
+
+    expect(position).toEqual({ left: 73, top: 748 });
+  });
+
+  it('positions the tooltip below the toggle source when toggle source pos is top-center', () => {
+    toggleSourceNode = {
+      getBoundingClientRect: () => ({ left: 400, top: 15, width: 50, height: 20 }),
+    };
+    window.pageYOffset = 0;
+    window.innerWidth = 800;
+
+    const position = positionTooltip(tooltipNode, toggleSourceNode);
+
+    expect(position).toEqual({ left: 345, top: 48 });
+  });
+
+  it('positions the tooltip above the toggle source when toggle source pos is bottom-center', () => {
+    toggleSourceNode = {
+      getBoundingClientRect: () => ({ left: 400, top: 760, width: 50, height: 20 }),
+    };
+    window.pageYOffset = 0;
+    window.innerWidth = 800;
+
+    const position = positionTooltip(tooltipNode, toggleSourceNode);
+
+    expect(position).toEqual({ left: 345, top: 712 });
+  });
+
+  it('positions the tooltip on the left of the toggle source when toggle source pos is top-right', () => {
+    toggleSourceNode = {
+      getBoundingClientRect: () => ({ left: 750, right: 800, top: 15, width: 50, height: 20 }),
+    };
+    window.innerWidth = 800;
+    window.pageYOffset = 0;
+
+    const position = positionTooltip(tooltipNode, toggleSourceNode);
+
+    expect(position).toEqual({ left: 582, top: 5 });
+  });
+
+  it('positions the tooltip on the left of the toggle source when toggle source pos is bottom-right', () => {
+    toggleSourceNode = {
+      getBoundingClientRect: () => ({ left: 750, right: 800, top: 760, width: 50, height: 20 }),
+    };
+    window.innerWidth = 800;
+    window.innerHeight = 800;
+    window.pageYOffset = 0;
+
+    const position = positionTooltip(tooltipNode, toggleSourceNode);
+
+    expect(position).toEqual({ left: 582, top: 750 });
+  });
 });

--- a/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
+++ b/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
@@ -32,20 +32,28 @@ const positionTop = (tooltipRect, toggleSourceRect) => {
   let left = toggleSourceRect.left - widthDifference;
   let top = toggleSourceRect.top - tooltipRect.height - SPACE_BETWEEN + window.pageYOffset;
 
-  //handle overflow top, left and righ viewport situations
-  const padding = window.innerWidth - toggleSourceRect.right;
-  const overflowRight = toggleSourceRect.left - padding + tooltipRect.width;
+  //CONDITIONS TO HANDLE TOOLTIP OVERFLOW OUT OF VIEWPORT
+
+  //calculate the space between rightside viewport to rightside source element
+  //knowing this space will help calculate if tooltip will overflow right side
+  const rightSpaceDifference = window.innerWidth - toggleSourceRect.right;
+
+  //calculate rightside pos of tooltip to compare later to window.innerWidth
+  const overflowRight = toggleSourceRect.left + tooltipRect.width - rightSpaceDifference;
 
   if (overflowRight > window.innerWidth) {
+    //if tooltip overflow right side of viewport
+    //place tooltip left side from source element
     left = toggleSourceRect.left - tooltipRect.width - SPACE_BETWEEN;
     top = toggleSourceRect.top + window.scrollY - toggleSourceRect.height / 2;
-  } else if (left < 0 && top > 0) {
+  } else if (left < 0) {
+    //if overflow left
+    //place tooltip right side from source element
     left = toggleSourceRect.width + toggleSourceRect.left + SPACE_BETWEEN;
     top = toggleSourceRect.top + window.scrollY - tooltipRect.height / 2 + SPACE_BETWEEN;
-  } else if (top < 0 && left < 0) {
-    left = toggleSourceRect.width + toggleSourceRect.left + SPACE_BETWEEN;
-    top = toggleSourceRect.height / 2;
   } else if (top < 0 && left > 0) {
+    //if overflow top but not left
+    //place tooltip below source element
     top = toggleSourceRect.height + tooltipRect.height / 2 + SPACE_BETWEEN;
   }
 

--- a/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
+++ b/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
@@ -32,14 +32,17 @@ const positionTop = (tooltipRect, toggleSourceRect) => {
   let left = toggleSourceRect.left - widthDifference;
   let top = toggleSourceRect.top - tooltipRect.height - SPACE_BETWEEN + window.pageYOffset;
 
-  const tooltipPos = tooltipRect.width + tooltipRect.left;
+  // const tooltipPos = tooltipRect.width + tooltipRect.left;
+  // console.log(tooltipRect.left, 'tooltip position');
+  // console.log(window.innerWidth, 'window innerwidth')
 
   //handle overflow top, left and righ viewport situations
-  if (tooltipPos === window.innerWidth) {
-    left = toggleSourceRect.left - tooltipRect.width - toggleSourceRect.width - SPACE_BETWEEN;
-    top = toggleSourceRect.height + tooltipRect.height / 2 + SPACE_BETWEEN;
-    top = toggleSourceRect.height / 2;
-  } else if (top < 0 && left < 0) {
+  // if (tooltipPos === window.innerWidth) {
+  //   left = toggleSourceRect.left - tooltipRect.width - toggleSourceRect.width - SPACE_BETWEEN;
+  //   top = toggleSourceRect.height + tooltipRect.height / 2 + SPACE_BETWEEN;
+  //   top = toggleSourceRect.height / 2;
+  // } else
+  if (top < 0 && left < 0) {
     left = toggleSourceRect.width + toggleSourceRect.left + SPACE_BETWEEN;
     top = toggleSourceRect.height / 2;
   } else if (top < 0 && left > 0) {

--- a/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
+++ b/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
@@ -32,17 +32,17 @@ const positionTop = (tooltipRect, toggleSourceRect) => {
   let left = toggleSourceRect.left - widthDifference;
   let top = toggleSourceRect.top - tooltipRect.height - SPACE_BETWEEN + window.pageYOffset;
 
-  // const tooltipPos = tooltipRect.width + tooltipRect.left;
-  // console.log(tooltipRect.left, 'tooltip position');
-  // console.log(window.innerWidth, 'window innerwidth')
-
   //handle overflow top, left and righ viewport situations
-  // if (tooltipPos === window.innerWidth) {
-  //   left = toggleSourceRect.left - tooltipRect.width - toggleSourceRect.width - SPACE_BETWEEN;
-  //   top = toggleSourceRect.height + tooltipRect.height / 2 + SPACE_BETWEEN;
-  //   top = toggleSourceRect.height / 2;
-  // } else
-  if (top < 0 && left < 0) {
+  const padding = window.innerWidth - toggleSourceRect.right;
+  const overflowRight = toggleSourceRect.left - padding + tooltipRect.width;
+
+  if (overflowRight > window.innerWidth) {
+    left = toggleSourceRect.left - tooltipRect.width - SPACE_BETWEEN;
+    top = toggleSourceRect.top + window.scrollY - toggleSourceRect.height / 2;
+  } else if (left < 0 && top > 0) {
+    left = toggleSourceRect.width + toggleSourceRect.left + SPACE_BETWEEN;
+    top = toggleSourceRect.top + window.scrollY - tooltipRect.height / 2 + SPACE_BETWEEN;
+  } else if (top < 0 && left < 0) {
     left = toggleSourceRect.width + toggleSourceRect.left + SPACE_BETWEEN;
     top = toggleSourceRect.height / 2;
   } else if (top < 0 && left > 0) {

--- a/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
+++ b/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
@@ -32,8 +32,8 @@ const positionTop = (tooltipRect, toggleSourceRect) => {
   let left = toggleSourceRect.left - widthDifference;
   let top = toggleSourceRect.top - tooltipRect.height - SPACE_BETWEEN + window.pageYOffset;
 
-  console.log('window.innerWidth', window.innerWidth);
-  console.log('toggleSourceRect.width + toggleSourceRect.left', toggleSourceRect.width + toggleSourceRect.left);
+  // console.log('window.innerWidth', window.innerWidth);
+  // console.log('toggleSourceRect.width + toggleSourceRect.left', toggleSourceRect.width + toggleSourceRect.left);
 
   //handle overflow top and left viewport situations
   if (top < 0 && left < 0) {

--- a/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
+++ b/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
@@ -29,8 +29,16 @@ const positionLeft = (tooltipRect, toggleSourceRect) => {
 
 const positionTop = (tooltipRect, toggleSourceRect) => {
   const widthDifference = (tooltipRect.width - toggleSourceRect.width) / 2;
-  const left = toggleSourceRect.left - widthDifference;
-  const top = toggleSourceRect.top - tooltipRect.height - SPACE_BETWEEN + window.pageYOffset;
+  let left = toggleSourceRect.left - widthDifference;
+  let top = toggleSourceRect.top - tooltipRect.height - SPACE_BETWEEN + window.pageYOffset;
+
+  //handle overflow top and left viewport situations
+  if (top < 0 && left < 0) {
+    left = toggleSourceRect.width + toggleSourceRect.left + SPACE_BETWEEN;
+    top = toggleSourceRect.height / 2;
+  } else if (top < 0 && left > 0) {
+    top = toggleSourceRect.height + tooltipRect.height / 2 + SPACE_BETWEEN;
+  }
 
   return {
     left,

--- a/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
+++ b/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
@@ -32,6 +32,9 @@ const positionTop = (tooltipRect, toggleSourceRect) => {
   let left = toggleSourceRect.left - widthDifference;
   let top = toggleSourceRect.top - tooltipRect.height - SPACE_BETWEEN + window.pageYOffset;
 
+  console.log('window.innerWidth', window.innerWidth);
+  console.log('toggleSourceRect.width + toggleSourceRect.left', toggleSourceRect.width + toggleSourceRect.left);
+
   //handle overflow top and left viewport situations
   if (top < 0 && left < 0) {
     left = toggleSourceRect.width + toggleSourceRect.left + SPACE_BETWEEN;

--- a/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
+++ b/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
@@ -32,11 +32,14 @@ const positionTop = (tooltipRect, toggleSourceRect) => {
   let left = toggleSourceRect.left - widthDifference;
   let top = toggleSourceRect.top - tooltipRect.height - SPACE_BETWEEN + window.pageYOffset;
 
-  // console.log('window.innerWidth', window.innerWidth);
-  // console.log('toggleSourceRect.width + toggleSourceRect.left', toggleSourceRect.width + toggleSourceRect.left);
+  const tooltipPos = tooltipRect.width + tooltipRect.left;
 
-  //handle overflow top and left viewport situations
-  if (top < 0 && left < 0) {
+  //handle overflow top, left and righ viewport situations
+  if (tooltipPos === window.innerWidth) {
+    left = toggleSourceRect.left - tooltipRect.width - toggleSourceRect.width - SPACE_BETWEEN;
+    top = toggleSourceRect.height + tooltipRect.height / 2 + SPACE_BETWEEN;
+    top = toggleSourceRect.height / 2;
+  } else if (top < 0 && left < 0) {
     left = toggleSourceRect.width + toggleSourceRect.left + SPACE_BETWEEN;
     top = toggleSourceRect.height / 2;
   } else if (top < 0 && left > 0) {


### PR DESCRIPTION
## What does it do?
Update tooltip left, right and top position when they overflow out of then screen + tests

## View
<img width="865" alt="Capture d’écran 2021-08-05 à 14 42 01" src="https://user-images.githubusercontent.com/71838159/128352355-1d926836-0841-4760-968e-f55547a69639.png">
<img width="862" alt="Capture d’écran 2021-08-05 à 14 42 13" src="https://user-images.githubusercontent.com/71838159/128352368-d0b64bee-984a-4146-bc44-e3e8ad4163de.png">
<img width="771" alt="Capture d’écran 2021-08-06 à 16 17 21" src="https://user-images.githubusercontent.com/71838159/128524113-cfef003d-817a-4511-bb33-83f539763e8d.png">
