### PR TITLE
Prevent popover from overflowing on the right side of the screen

### DIFF
--- a/packages/strapi-parts/src/Popover/Popover.js
+++ b/packages/strapi-parts/src/Popover/Popover.js
@@ -1,18 +1,32 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Box } from '../Box';
 import { Portal } from '../Portal';
 import { useIntersection } from '../helpers/useIntersection';
+import { useResizeObserver } from '../helpers/useResizeObserver';
 
-const position = (source, fullWidth) => {
+export const position = (source, popover, fullWidth) => {
   const rect = source.getBoundingClientRect();
-
   const left = rect.left + window.pageXOffset;
   const top = rect.top + rect.height + window.pageYOffset;
 
+  if (!popover) {
+    return {
+      left,
+      top,
+      width: fullWidth ? rect.width : undefined,
+    };
+  }
+
+  const popoverRect = popover.getBoundingClientRect();
+  const scrollbarWidth = popover.offsetWidth - popover.clientWidth;
+
   return {
-    left,
+    left:
+      popoverRect.left + popoverRect.width > window.innerWidth
+        ? window.innerWidth - popoverRect.width - scrollbarWidth
+        : left,
     top,
     width: fullWidth ? rect.width : undefined,
   };
@@ -49,21 +63,9 @@ const PopoverScrollable = styled(Box)`
 
 const PopoverContent = ({ source, children, spacingTop, fullWidth, onReachEnd, intersectionId, ...props }) => {
   const popoverRef = useRef(null);
-  const [{ left, top, width }, setPosition] = useState(position(source.current, fullWidth));
+  const [{ left, top, width }, setPosition] = useState(position(source.current, popoverRef.current, fullWidth));
 
-  useEffect(() => {
-    const resizeHandler = () => {
-      setPosition(position(source.current, fullWidth));
-    };
-
-    const resizeObs = new ResizeObserver(resizeHandler);
-    resizeObs.observe(source.current);
-
-    return () => {
-      resizeObs.disconnect();
-    };
-  }, []);
-
+  useResizeObserver(source, () => setPosition(position(source.current, popoverRef.current, fullWidth)));
   useIntersection(popoverRef, onReachEnd, {
     selectorToWatch: `#${intersectionId}`,
     skipWhen: !intersectionId || !onReachEnd,

--- a/packages/strapi-parts/src/Popover/Popover.js
+++ b/packages/strapi-parts/src/Popover/Popover.js
@@ -20,13 +20,9 @@ export const position = (source, popover, fullWidth) => {
   }
 
   const popoverRect = popover.getBoundingClientRect();
-  const scrollbarWidth = popover.offsetWidth - popover.clientWidth;
 
   return {
-    left:
-      popoverRect.left + popoverRect.width > window.innerWidth
-        ? window.innerWidth - popoverRect.width - scrollbarWidth
-        : left,
+    left: popoverRect.left + popoverRect.width > window.innerWidth ? window.innerWidth - popoverRect.width - 20 : left,
     top,
     width: fullWidth ? rect.width : undefined,
   };

--- a/packages/strapi-parts/src/Popover/Popover.stories.mdx
+++ b/packages/strapi-parts/src/Popover/Popover.stories.mdx
@@ -92,23 +92,25 @@ Description...
       const [visible, setVisible] = useState(false);
       const buttonRef = useRef();
       return (
-        <Row justifyContent="right">
-          <button ref={buttonRef} onClick={() => setVisible((s) => !s)}>
-            Open popover
-          </button>
-          {visible && (
-            <Popover source={buttonRef} spacingTop={4}>
-              <ul style={{ width: '200px' }}>
-                {Array(15)
-                  .fill(null)
-                  .map((_, index) => (
-                    <Box key={index} padding={3}>
-                      Element {index}
-                    </Box>
-                  ))}
-              </ul>
-            </Popover>
-          )}
+        <Row justifyContent="flex-end">
+          <div>
+            <button ref={buttonRef} onClick={() => setVisible((s) => !s)}>
+              Open popover
+            </button>
+            {visible && (
+              <Popover source={buttonRef} spacingTop={4}>
+                <ul style={{ width: '200px' }}>
+                  {Array(15)
+                    .fill(null)
+                    .map((_, index) => (
+                      <Box key={index} padding={3}>
+                        Element {index}
+                      </Box>
+                    ))}
+                </ul>
+              </Popover>
+            )}
+          </div>
         </Row>
       );
     }}

--- a/packages/strapi-parts/src/Popover/Popover.stories.mdx
+++ b/packages/strapi-parts/src/Popover/Popover.stories.mdx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Popover } from './Popover';
 import { Box } from '../Box';
+import { Row } from '../Row';
 import { Button } from '../Button';
 import { Stack } from '../Stack';
 
@@ -76,6 +77,39 @@ Description...
             </ul>
           </Popover>
         </Box>
+      );
+    }}
+  </Story>
+</Canvas>
+
+## Popover
+
+Description...
+
+<Canvas>
+  <Story name="overflow-right">
+    {() => {
+      const [visible, setVisible] = useState(false);
+      const buttonRef = useRef();
+      return (
+        <Row justifyContent="right">
+          <button ref={buttonRef} onClick={() => setVisible((s) => !s)}>
+            Open popover
+          </button>
+          {visible && (
+            <Popover source={buttonRef} spacingTop={4}>
+              <ul style={{ width: '200px' }}>
+                {Array(15)
+                  .fill(null)
+                  .map((_, index) => (
+                    <Box key={index} padding={3}>
+                      Element {index}
+                    </Box>
+                  ))}
+              </ul>
+            </Popover>
+          )}
+        </Row>
       );
     }}
   </Story>

--- a/packages/strapi-parts/src/helpers/useResizeObserver.js
+++ b/packages/strapi-parts/src/helpers/useResizeObserver.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export const useResizeObserver = (source, onResize) => {
+  useEffect(() => {
+    const resizeObs = new ResizeObserver(onResize);
+    resizeObs.observe(source.current);
+
+    return () => {
+      resizeObs.disconnect();
+    };
+  }, []);
+};


### PR DESCRIPTION
## Description
Prevents the popover from overflowing when it's out of the screen on the right side

## Demo
Example on : https://design-system-git-popover-overflow-strapijs.vercel.app/?path=/story/design-system-molecules-popover--overflow-right

<img width="1920" alt="Popover not overflowing on the screen" src="https://user-images.githubusercontent.com/3874873/128361503-83f0d0b7-88c5-454c-9e13-3e5c908dbb5f.png">

