### PR TITLE
Add simple variant for tabs

### DIFF
--- a/packages/strapi-parts/src/Tabs/TabGroup.js
+++ b/packages/strapi-parts/src/Tabs/TabGroup.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import { TabsContext } from './TabsContext';
 import { useId } from '../helpers/useId';
 
-export const TabGroup = ({ id, label, ...props }) => {
+export const TabGroup = ({ id, label, variant, ...props }) => {
   const tabsId = useId('tabgroup', id);
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 
   return (
-    <TabsContext.Provider value={{ id: tabsId, selectedTabIndex, selectTabIndex: setSelectedTabIndex, label }}>
+    <TabsContext.Provider value={{ id: tabsId, selectedTabIndex, selectTabIndex: setSelectedTabIndex, label, variant }}>
       <div {...props} />
     </TabsContext.Provider>
   );
@@ -16,9 +16,11 @@ export const TabGroup = ({ id, label, ...props }) => {
 
 TabGroup.defaultProps = {
   id: undefined,
+  variant: undefined,
 };
 
 TabGroup.propTypes = {
   id: PropTypes.string,
   label: PropTypes.string.isRequired,
+  variant: PropTypes.oneOf(['simple']),
 };

--- a/packages/strapi-parts/src/Tabs/Tabs.stories.mdx
+++ b/packages/strapi-parts/src/Tabs/Tabs.stories.mdx
@@ -5,11 +5,10 @@ import { Tabs, Tab } from './Tabs';
 import { TabGroup } from './TabGroup';
 import { TabPanels, TabPanel } from './TabPanels';
 import { Box } from '../Box';
+import { Row } from '../Row';
+import { Badge } from '../Badge';
 
-<Meta
-  title="Design System/Molecules/Tabs"
-  component={Tabs}
-/>
+<Meta title="Design System/Molecules/Tabs" component={Tabs} />
 
 # Tabs
 
@@ -26,6 +25,41 @@ Description...
         <Tabs>
           <Tab>First</Tab>
           <Tab>Second</Tab>
+          <Tab>Third</Tab>
+        </Tabs>
+        <TabPanels>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              First panel
+            </Box>
+          </TabPanel>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              Second panel
+            </Box>
+          </TabPanel>
+          <TabPanel>
+            <Box padding={4} background="neutral0">
+              Third panel
+            </Box>
+          </TabPanel>
+        </TabPanels>
+      </TabGroup>
+    </Box>
+  </Story>
+</Canvas>
+
+## Tabs simple
+
+Description...
+
+<Canvas>
+  <Story name="simple">
+    <Box padding={8} background="neutral0">
+      <TabGroup label="Some stuff for the label" id="tabs" variant="simple">
+        <Tabs>
+          <Tab>First</Tab>
+          <Tab hasError>Second</Tab>
           <Tab>Third</Tab>
         </Tabs>
         <TabPanels>

--- a/packages/strapi-parts/src/Tabs/__tests__/Tabs.e2e.js
+++ b/packages/strapi-parts/src/Tabs/__tests__/Tabs.e2e.js
@@ -1,32 +1,18 @@
 import { injectAxe, checkA11y } from 'axe-playwright';
 
 describe('Tabs', () => {
-  beforeEach(async () => {
-    // This is the URL of the Storybook Iframe
-    await page.goto('http://localhost:6006/iframe.html?id=design-system-molecules-tabs--base&viewMode=story');
-    await injectAxe(page);
-  });
+  describe('default variant', () => {
+    beforeEach(async () => {
+      // This is the URL of the Storybook Iframe
+      await page.goto('http://localhost:6006/iframe.html?id=design-system-molecules-tabs--base&viewMode=story');
+      await injectAxe(page);
+    });
 
-  it('triggers axe on the document', async () => {
-    await checkA11y(page);
-  });
+    it('triggers axe on the document', async () => {
+      await checkA11y(page);
+    });
 
-  it('verifies that only the first panel is visible at the beginning', async () => {
-    const isFirstPanelVisible = await page.isVisible('text="First panel"');
-    expect(isFirstPanelVisible).toBeTruthy();
-
-    const isSecondPanelVisible = await page.isVisible('text="Second panel"');
-    expect(isSecondPanelVisible).toBeFalsy();
-
-    const isThirdPanelVisible = await page.isVisible('text="Third panel"');
-    expect(isThirdPanelVisible).toBeFalsy();
-  });
-
-  describe('Click interactions', () => {
-    it('shows only the first panel when clicking on it', async () => {
-      await page.click('text="Second"');
-      await page.click('text="First"');
-
+    it('verifies that only the first panel is visible at the beginning', async () => {
       const isFirstPanelVisible = await page.isVisible('text="First panel"');
       expect(isFirstPanelVisible).toBeTruthy();
 
@@ -37,79 +23,107 @@ describe('Tabs', () => {
       expect(isThirdPanelVisible).toBeFalsy();
     });
 
-    it('shows only the second panel when clicking on it', async () => {
-      await page.click('text="Second"');
+    describe('Click interactions', () => {
+      it('shows only the first panel when clicking on it', async () => {
+        await page.click('text="Second"');
+        await page.click('text="First"');
 
-      const isFirstPanelVisible = await page.isVisible('text="First panel"');
-      expect(isFirstPanelVisible).toBeFalsy();
+        const isFirstPanelVisible = await page.isVisible('text="First panel"');
+        expect(isFirstPanelVisible).toBeTruthy();
 
-      const isSecondPanelVisible = await page.isVisible('text="Second panel"');
-      expect(isSecondPanelVisible).toBeTruthy();
+        const isSecondPanelVisible = await page.isVisible('text="Second panel"');
+        expect(isSecondPanelVisible).toBeFalsy();
 
-      const isThirdPanelVisible = await page.isVisible('text="Third panel"');
-      expect(isThirdPanelVisible).toBeFalsy();
+        const isThirdPanelVisible = await page.isVisible('text="Third panel"');
+        expect(isThirdPanelVisible).toBeFalsy();
+      });
+
+      it('shows only the second panel when clicking on it', async () => {
+        await page.click('text="Second"');
+
+        const isFirstPanelVisible = await page.isVisible('text="First panel"');
+        expect(isFirstPanelVisible).toBeFalsy();
+
+        const isSecondPanelVisible = await page.isVisible('text="Second panel"');
+        expect(isSecondPanelVisible).toBeTruthy();
+
+        const isThirdPanelVisible = await page.isVisible('text="Third panel"');
+        expect(isThirdPanelVisible).toBeFalsy();
+      });
+
+      it('shows only the third panel when clicking on it', async () => {
+        await page.click('text="Third"');
+
+        const isFirstPanelVisible = await page.isVisible('text="First panel"');
+        expect(isFirstPanelVisible).toBeFalsy();
+
+        const isSecondPanelVisible = await page.isVisible('text="Second panel"');
+        expect(isSecondPanelVisible).toBeFalsy();
+
+        const isThirdPanelVisible = await page.isVisible('text="Third panel"');
+        expect(isThirdPanelVisible).toBeTruthy();
+      });
     });
 
-    it('shows only the third panel when clicking on it', async () => {
-      await page.click('text="Third"');
+    describe('Keyboard interactions', () => {
+      it('moves to the next tab when pressing ArrowRight', async () => {
+        await page.waitForSelector('#tabs-0-tab');
 
-      const isFirstPanelVisible = await page.isVisible('text="First panel"');
-      expect(isFirstPanelVisible).toBeFalsy();
+        await page.focus('#tabs-0-tab');
+        await page.keyboard.press('ArrowRight');
+        await expect(page).toHaveFocus('#tabs-1-tab');
 
-      const isSecondPanelVisible = await page.isVisible('text="Second panel"');
-      expect(isSecondPanelVisible).toBeFalsy();
+        await page.keyboard.press('ArrowRight');
+        await expect(page).toHaveFocus('#tabs-2-tab');
 
-      const isThirdPanelVisible = await page.isVisible('text="Third panel"');
-      expect(isThirdPanelVisible).toBeTruthy();
+        await page.keyboard.press('ArrowRight');
+        await expect(page).toHaveFocus('#tabs-0-tab');
+      });
+
+      it('moves to the previous tab when pressing ArrowLeft', async () => {
+        await page.waitForSelector('#tabs-0-tab');
+
+        await page.focus('#tabs-0-tab');
+        await page.keyboard.press('ArrowLeft');
+        await expect(page).toHaveFocus('#tabs-2-tab');
+
+        await page.keyboard.press('ArrowLeft');
+        await expect(page).toHaveFocus('#tabs-1-tab');
+
+        await page.keyboard.press('ArrowLeft');
+        await expect(page).toHaveFocus('#tabs-0-tab');
+      });
+
+      it('moves to the first tab when pressing Home', async () => {
+        await page.waitForSelector('#tabs-0-tab');
+
+        await page.focus('#tabs-0-tab');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('Home');
+
+        await expect(page).toHaveFocus('#tabs-0-tab');
+      });
+
+      it('moves to the last tab when pressing End', async () => {
+        await page.waitForSelector('#tabs-0-tab');
+
+        await page.focus('#tabs-0-tab');
+        await page.keyboard.press('End');
+
+        await expect(page).toHaveFocus('#tabs-2-tab');
+      });
     });
   });
 
-  describe('Keyboard interactions', () => {
-    it('moves to the next tab when pressing ArrowRight', async () => {
-      await page.waitForSelector('#tabs-0-tab');
-
-      await page.focus('#tabs-0-tab');
-      await page.keyboard.press('ArrowRight');
-      await expect(page).toHaveFocus('#tabs-1-tab');
-
-      await page.keyboard.press('ArrowRight');
-      await expect(page).toHaveFocus('#tabs-2-tab');
-
-      await page.keyboard.press('ArrowRight');
-      await expect(page).toHaveFocus('#tabs-0-tab');
+  describe('simple variant', () => {
+    beforeEach(async () => {
+      // This is the URL of the Storybook Iframe
+      await page.goto('http://localhost:6006/iframe.html?id=design-system-molecules-tabs--simple&viewMode=story');
+      await injectAxe(page);
     });
 
-    it('moves to the previous tab when pressing ArrowLeft', async () => {
-      await page.waitForSelector('#tabs-0-tab');
-
-      await page.focus('#tabs-0-tab');
-      await page.keyboard.press('ArrowLeft');
-      await expect(page).toHaveFocus('#tabs-2-tab');
-
-      await page.keyboard.press('ArrowLeft');
-      await expect(page).toHaveFocus('#tabs-1-tab');
-
-      await page.keyboard.press('ArrowLeft');
-      await expect(page).toHaveFocus('#tabs-0-tab');
-    });
-
-    it('moves to the first tab when pressing Home', async () => {
-      await page.waitForSelector('#tabs-0-tab');
-
-      await page.focus('#tabs-0-tab');
-      await page.keyboard.press('ArrowLeft');
-      await page.keyboard.press('Home');
-
-      await expect(page).toHaveFocus('#tabs-0-tab');
-    });
-
-    it('moves to the last tab when pressing End', async () => {
-      await page.waitForSelector('#tabs-0-tab');
-
-      await page.focus('#tabs-0-tab');
-      await page.keyboard.press('End');
-
-      await expect(page).toHaveFocus('#tabs-2-tab');
+    it('triggers axe on the document', async () => {
+      await checkA11y(page);
     });
   });
 });

--- a/packages/strapi-parts/src/Tabs/__tests__/Tabs.spec.js
+++ b/packages/strapi-parts/src/Tabs/__tests__/Tabs.spec.js
@@ -26,6 +26,25 @@ describe('Tabs', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
+      .c7 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #271fe0;
+      }
+
+      .c11 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #666687;
+      }
+
+      .c8 {
+        font-weight: 600;
+        line-height: 1.14;
+      }
+
       .c5 {
         background: #ffffff;
         padding: 16px;
@@ -48,25 +67,6 @@ describe('Tabs', () => {
         -webkit-box-align: flex-end;
         -ms-flex-align: flex-end;
         align-items: flex-end;
-      }
-
-      .c7 {
-        font-weight: 400;
-        font-size: 0.875rem;
-        line-height: 1.43;
-        color: #271fe0;
-      }
-
-      .c11 {
-        font-weight: 400;
-        font-size: 0.875rem;
-        line-height: 1.43;
-        color: #666687;
-      }
-
-      .c8 {
-        font-weight: 600;
-        line-height: 1.14;
       }
 
       .c6 {
@@ -169,6 +169,132 @@ describe('Tabs', () => {
           <div
             aria-labelledby="tabgroup-1-0-tab"
             id="tabgroup-1-0-tabpanel"
+            role="tabpanel"
+            tabindex="0"
+          >
+            First panel
+          </div>
+        </div>
+      </div>
+    `);
+  });
+
+  it('snapshots the component in simpel variant', () => {
+    const { container } = render(
+      <ThemeProvider theme={lightTheme}>
+        <TabGroup label="Some stuff for the label" variant="simple">
+          <Tabs>
+            <Tab>First</Tab>
+            <Tab>Second</Tab>
+            <Tab>Third</Tab>
+          </Tabs>
+          <TabPanels>
+            <TabPanel>First panel</TabPanel>
+            <TabPanel>Second panel</TabPanel>
+            <TabPanel>Third panel</TabPanel>
+          </TabPanels>
+        </TabGroup>
+      </ThemeProvider>,
+    );
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      .c2 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #4945ff;
+      }
+
+      .c6 {
+        font-weight: 400;
+        font-size: 0.875rem;
+        line-height: 1.43;
+        color: #666687;
+      }
+
+      .c3 {
+        font-weight: 600;
+        line-height: 1.14;
+      }
+
+      .c4 {
+        font-weight: 600;
+        font-size: 0.6875rem;
+        line-height: 1.45;
+        text-transform: uppercase;
+      }
+
+      .c0 {
+        padding: 16px;
+      }
+
+      .c1 {
+        border-bottom: 2px solid #4945ff;
+      }
+
+      .c5 {
+        border-bottom: 2px solid transparent;
+      }
+
+      <div>
+        <div
+          aria-label="Some stuff for the label"
+          role="tablist"
+        >
+          <button
+            aria-controls="tabgroup-2-0-tabpanel"
+            aria-selected="true"
+            id="tabgroup-2-0-tab"
+            role="tab"
+            tabindex="0"
+          >
+            <div
+              class="c0 c1"
+            >
+              <span
+                class="c2 c3 c4"
+              >
+                First
+              </span>
+            </div>
+          </button>
+          <button
+            aria-selected="false"
+            id="tabgroup-2-1-tab"
+            role="tab"
+            tabindex="-1"
+          >
+            <div
+              class="c0 c5"
+            >
+              <span
+                class="c6 c3 c4"
+              >
+                Second
+              </span>
+            </div>
+          </button>
+          <button
+            aria-selected="false"
+            id="tabgroup-2-2-tab"
+            role="tab"
+            tabindex="-1"
+          >
+            <div
+              class="c0 c5"
+            >
+              <span
+                class="c6 c3 c4"
+              >
+                Third
+              </span>
+            </div>
+          </button>
+        </div>
+        <div>
+          <div
+            aria-labelledby="tabgroup-2-0-tab"
+            id="tabgroup-2-0-tabpanel"
             role="tabpanel"
             tabindex="0"
           >

--- a/packages/strapi-parts/src/Tabs/components.js
+++ b/packages/strapi-parts/src/Tabs/components.js
@@ -5,8 +5,17 @@ import { Row } from '../Row';
 /** Simple variant */
 export const SimpleTabBox = styled(Box)`
   border-bottom: 2px solid
-    ${({ theme, selected, hasError }) =>
-      hasError ? theme.colors.danger600 : selected ? theme.colors.primary600 : 'transparent'};
+    ${({ theme, selected, hasError }) => {
+      if (selected) {
+        if (hasError) {
+          return theme.colors.danger600;
+        }
+
+        return theme.colors.primary600;
+      }
+
+      return 'transparent';
+    }};
 `;
 
 /** Default variant */

--- a/packages/strapi-parts/src/Tabs/components.js
+++ b/packages/strapi-parts/src/Tabs/components.js
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import { Box } from '../Box';
+import { Row } from '../Row';
+
+/** Simple variant */
+export const SimpleTabBox = styled(Box)`
+  border-bottom: 2px solid
+    ${({ theme, selected, hasError }) =>
+      hasError ? theme.colors.danger600 : selected ? theme.colors.primary600 : 'transparent'};
+`;
+
+/** Default variant */
+export const DefaultTabBox = styled(Box)`
+  border-bottom: 1px solid ${({ theme, selected }) => (selected ? theme.colors.neutral0 : theme.colors.neutral150)};
+`;
+
+export const DefaultTabButton = styled.button`
+  border: none;
+  background: transparent;
+  padding: 0;
+
+  & + & > ${DefaultTabBox} {
+    border-left: 1px solid ${({ theme }) => theme.colors.neutral150};
+  }
+
+  // Hack preventing the outline from being overflow by the following tab
+  outline-offset: -2px;
+`;
+
+export const DefaultTabsRow = styled(Row)`
+  & > * {
+    flex: 1;
+  }
+
+  & ${DefaultTabButton}:first-of-type ${DefaultTabBox} {
+    border-radius: ${({ theme }) => `${theme.borderRadius} 0 0 0`};
+  }
+
+  & ${DefaultTabButton}:last-of-type ${DefaultTabBox} {
+    border-radius: ${({ theme }) => `0 ${theme.borderRadius} 0 0`};
+  }
+
+  & ${DefaultTabButton}[aria-selected="true"] ${DefaultTabBox} {
+    border-radius: ${({ theme }) => `${theme.borderRadius} ${theme.borderRadius} 0 0`};
+  }
+`;


### PR DESCRIPTION

## Description

Add simple variant for the tabs component

## Demo

Example on : https://design-system-git-tabs-simple-strapijs.vercel.app/?path=/story/design-system-molecules-tabs--simple

## API

```diff
<TabGroup
   label="Some stuff for the label"
+  variant="simple"
>
  <Tabs>
    <Tab>First</Tab>
    <Tab>Second</Tab>
    <Tab>Third</Tab>
  </Tabs>
  <TabPanels>
    <TabPanel>First panel</TabPanel>
    <TabPanel>Second panel</TabPanel>
    <TabPanel>Third panel</TabPanel>
  </TabPanels>
</TabGroup>
```

## Voiceover

<img width="390" alt="Tabs using the 'simple' variant" src="https://user-images.githubusercontent.com/3874873/128474713-e6f6f370-d772-447d-9d45-47f3fb24b07f.png">
