### PR TITLE
Removing aria-hidden from NavBrand

### DIFF
--- a/packages/strapi-parts/src/MainNav/NavBrand.js
+++ b/packages/strapi-parts/src/MainNav/NavBrand.js
@@ -24,9 +24,7 @@ export const NavBrand = ({ workplace, title, icon }) => {
   if (condensed) {
     return (
       <Box paddingLeft={3} paddingRight={3} paddingTop={4} paddingBottom={4}>
-        <BrandIconWrapper aria-hidden condensed={true}>
-          {icon}
-        </BrandIconWrapper>
+        <BrandIconWrapper condensed={true}>{icon}</BrandIconWrapper>
 
         <VisuallyHidden>
           <span>{title}</span>
@@ -39,7 +37,7 @@ export const NavBrand = ({ workplace, title, icon }) => {
   return (
     <Box paddingLeft={3} paddingRight={3} paddingTop={4} paddingBottom={4}>
       <Row>
-        <BrandIconWrapper aria-hidden>{icon}</BrandIconWrapper>
+        <BrandIconWrapper>{icon}</BrandIconWrapper>
 
         <Box paddingLeft={2}>
           <TextButton textColor="neutral800">{title}</TextButton>

--- a/packages/strapi-parts/src/MainNav/__tests__/MainNav.spec.js
+++ b/packages/strapi-parts/src/MainNav/__tests__/MainNav.spec.js
@@ -254,7 +254,6 @@ describe('MainNav', () => {
             class="c2"
           >
             <div
-              aria-hidden="true"
               class="c3"
             >
               <span>
@@ -734,7 +733,6 @@ describe('MainNav', () => {
           class="c1"
         >
           <div
-            aria-hidden="true"
             class="c2"
           >
             <span>


### PR DESCRIPTION
aria-hidden on the NavBrand is not necessary since passing an empty alt in the image would make it being ignored. 