### PR TITLE
Fixed centering calculations && popover ref moved

### DIFF
--- a/packages/strapi-parts/src/Popover/Popover.js
+++ b/packages/strapi-parts/src/Popover/Popover.js
@@ -21,9 +21,6 @@ export const position = (source, popover, fullWidth, centered) => {
 
   const popoverRect = popover.getBoundingClientRect();
 
-  // const widthDifference = (tooltipRect.width - toggleSourceRect.width) / 2;
-  // let left = toggleSourceRect.left - widthDifference;
-
   if (centered) {
     const popoverBorderPadding = 10;
     const popoverTotalWidth = popoverRect.width + popoverBorderPadding;

--- a/packages/strapi-parts/src/Popover/Popover.js
+++ b/packages/strapi-parts/src/Popover/Popover.js
@@ -21,8 +21,14 @@ export const position = (source, popover, fullWidth, centered) => {
 
   const popoverRect = popover.getBoundingClientRect();
 
+  // const widthDifference = (tooltipRect.width - toggleSourceRect.width) / 2;
+  // let left = toggleSourceRect.left - widthDifference;
+
   if (centered) {
-    const widthDifference = (rect.width - popoverRect.width) / 2;
+    const popoverBorderPadding = 10;
+    const popoverTotalWidth = popoverRect.width + popoverBorderPadding;
+    const widthDifference = (rect.width - popoverTotalWidth) / 2;
+
     left = rect.left + widthDifference + window.pageXOffset;
   }
 
@@ -98,8 +104,8 @@ const PopoverContent = ({
   };
 
   return (
-    <PopoverWrapper ref={popoverRef} style={style} hasRadius background="neutral0" padding={1} spacingTop={spacingTop}>
-      <PopoverScrollable {...props}>
+    <PopoverWrapper style={style} hasRadius background="neutral0" padding={1} spacingTop={spacingTop}>
+      <PopoverScrollable ref={popoverRef} {...props}>
         {children}
         {intersectionId && onReachEnd && <div id={intersectionId} />}
       </PopoverScrollable>

--- a/packages/strapi-parts/src/Popover/Popover.js
+++ b/packages/strapi-parts/src/Popover/Popover.js
@@ -11,10 +11,6 @@ export const position = (source, popover, fullWidth, centered) => {
   let top = rect.top + rect.height + window.pageYOffset;
   let left = rect.left + window.pageXOffset;
 
-  if (centered) {
-    left = rect.left - rect.width / 2 + window.pageXOffset;
-  }
-
   if (!popover) {
     return {
       left,
@@ -24,6 +20,14 @@ export const position = (source, popover, fullWidth, centered) => {
   }
 
   const popoverRect = popover.getBoundingClientRect();
+
+  if (centered) {
+    console.log('went here centered');
+    console.log(popoverRect.width);
+    const widthDifference = (rect.width - popoverRect.width) / 2;
+    left = rect.left + widthDifference + window.pageXOffset;
+  }
+
   //if popover overflows left or right viewport
   if (popoverRect.left < 0) {
     left = rect.left + window.pageXOffset;
@@ -96,8 +100,8 @@ const PopoverContent = ({
   };
 
   return (
-    <PopoverWrapper style={style} hasRadius background="neutral0" padding={1} spacingTop={spacingTop}>
-      <PopoverScrollable ref={popoverRef} {...props}>
+    <PopoverWrapper ref={popoverRef} style={style} hasRadius background="neutral0" padding={1} spacingTop={spacingTop}>
+      <PopoverScrollable {...props}>
         {children}
         {intersectionId && onReachEnd && <div id={intersectionId} />}
       </PopoverScrollable>

--- a/packages/strapi-parts/src/Popover/Popover.js
+++ b/packages/strapi-parts/src/Popover/Popover.js
@@ -22,8 +22,6 @@ export const position = (source, popover, fullWidth, centered) => {
   const popoverRect = popover.getBoundingClientRect();
 
   if (centered) {
-    console.log('went here centered');
-    console.log(popoverRect.width);
     const widthDifference = (rect.width - popoverRect.width) / 2;
     left = rect.left + widthDifference + window.pageXOffset;
   }

--- a/packages/strapi-parts/src/Popover/Popover.stories.mdx
+++ b/packages/strapi-parts/src/Popover/Popover.stories.mdx
@@ -24,7 +24,7 @@ Description...
       const [visible, setVisible] = useState(false);
       const buttonRef = useRef();
       return (
-        <Box padding={10}>
+        <div style={{ marginLeft: '200px' }}>
           <button ref={buttonRef} onClick={() => setVisible((s) => !s)}>
             Open popover
           </button>
@@ -41,7 +41,7 @@ Description...
               </ul>
             </Popover>
           )}
-        </Box>
+        </div>
       );
     }}
   </Story>

--- a/packages/strapi-parts/src/Popover/__tests__/Popover.spec.js
+++ b/packages/strapi-parts/src/Popover/__tests__/Popover.spec.js
@@ -43,12 +43,16 @@ describe('Popover', () => {
     });
 
     it('position the tooltip centered to source element if centered props', () => {
-      const source = { getBoundingClientRect: () => ({ left: 500, top: 10, width: 100, height: 20 }) };
+      const source = { getBoundingClientRect: () => ({ left: 500, top: 10, width: 200, height: 20 }) };
       const centered = true;
-      const popover = null;
+      const popover = {
+        offsetWidth: 100,
+        clientWidth: 85,
+        getBoundingClientRect: () => ({ width: 100 }),
+      };
       const fullWidth = null;
 
-      expect(position(source, popover, fullWidth, centered)).toEqual({ left: 450, top: 30, width: undefined });
+      expect(position(source, popover, fullWidth, centered)).toEqual({ left: 550, top: 30, width: undefined });
     });
   });
 

--- a/packages/strapi-parts/src/Popover/__tests__/Popover.spec.js
+++ b/packages/strapi-parts/src/Popover/__tests__/Popover.spec.js
@@ -52,7 +52,7 @@ describe('Popover', () => {
       };
       const fullWidth = null;
 
-      expect(position(source, popover, fullWidth, centered)).toEqual({ left: 550, top: 30, width: undefined });
+      expect(position(source, popover, fullWidth, centered)).toEqual({ left: 545, top: 30, width: undefined });
     });
   });
 


### PR DESCRIPTION
## What/why

- Centering calculations fixed (based on popover width and not source element width)
- Popover ref moved to PopoverWrapper, if not padding and border couldn't be part of positioning calculations

