### PR TITLE
Add outline none to main component

### DIFF
--- a/packages/strapi-parts/src/Main/Main.js
+++ b/packages/strapi-parts/src/Main/Main.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const MainWrapper = styled.main`
+  outline: none;
+`;
 
 export const Main = ({ labelledBy, ...props }) => {
-  return <main aria-labelledby={labelledBy} id="main-content" tabIndex={-1} {...props} />;
+  return <MainWrapper aria-labelledby={labelledBy} id="main-content" tabIndex={-1} {...props} />;
 };
 
 Main.propTypes = {

--- a/packages/strapi-parts/src/Main/__tests__/Main.spec.js
+++ b/packages/strapi-parts/src/Main/__tests__/Main.spec.js
@@ -19,6 +19,10 @@ describe('Main', () => {
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`
+      .c2 {
+        outline: none;
+      }
+
       .c0 {
         background: #4945ff;
         color: #ffffff;
@@ -49,6 +53,7 @@ describe('Main', () => {
         </a>
         <main
           aria-labelledby="main-title"
+          class="c2"
           id="main-content"
           tabindex="-1"
         >


### PR DESCRIPTION
When navigating to the a specific page using the keyboard, instead of leaving the keyboard on the selected link, it would great to send the focus to the main element of the new page to facilitate people navigation.

While the Main component has already a tabindex="-1" (meaning focusable programmatically), it has an outline and it's weird to see it on the screen. 

So as server-side rendered page, I would like to try, on page transition, to send the focus on the Main element of the page so that it's announced 😊 . There's no outline for server-rendered page, so I suggest that there's no outline neither on client side navigation 😊 