### PR TITLE
Replaced OneBlockLayout with Layout component

### DIFF
--- a/example/src/CM/index.js
+++ b/example/src/CM/index.js
@@ -81,22 +81,7 @@ const CM = () => {
 
   return (
     <AppLayout>
-      <Layout
-        header={
-          <HeaderLayout
-            primaryAction={
-              <Button startIcon={<AddIcon />}>Add an entry</Button>
-            }
-            secondaryAction={
-              <Button variant="tertiary" startIcon={<EditIcon />}>
-                Edit
-              </Button>
-            }
-            title="Other CT"
-            subtitle="36 entries found"
-          />
-        }
-      >
+      <Layout>
         <form onSubmit={handleSubmit}>
           <Box padding={6}>
             <Stack size={6}>

--- a/example/src/CM/index.js
+++ b/example/src/CM/index.js
@@ -7,7 +7,7 @@ import {
   GridItem,
   HeaderLayout,
   Stack,
-  OneBlockLayout,
+  Layout,
 } from "@strapi/parts";
 import EditIcon from "@strapi/icons/EditIcon";
 import AddIcon from "@strapi/icons/AddIcon";
@@ -81,7 +81,7 @@ const CM = () => {
 
   return (
     <AppLayout>
-      <OneBlockLayout
+      <Layout
         header={
           <HeaderLayout
             primaryAction={
@@ -120,7 +120,7 @@ const CM = () => {
             </Stack>
           </Box>
         </form>
-      </OneBlockLayout>
+      </Layout>
     </AppLayout>
   );
 };


### PR DESCRIPTION
## What/why

Replaced OneBlockLayout with Layout component in parts/example

<img width="1432" alt="Capture d’écran 2021-08-11 à 16 27 19" src="https://user-images.githubusercontent.com/71838159/129047525-6fac446a-292e-4bd9-aa64-ec0db8425c59.png">
