### PR TITLE
Fixed tooltip top pos when overflow top

### DIFF
--- a/packages/strapi-parts/src/Tooltip/utils/__tests__/positionTooltip.spec.js
+++ b/packages/strapi-parts/src/Tooltip/utils/__tests__/positionTooltip.spec.js
@@ -72,7 +72,7 @@ describe('positionTooltip', () => {
 
     const position = positionTooltip(tooltipNode, toggleSourceNode);
 
-    expect(position).toEqual({ left: 345, top: 48 });
+    expect(position).toEqual({ left: 345, top: 43 });
   });
 
   it('positions the tooltip above the toggle source when toggle source pos is bottom-center', () => {

--- a/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
+++ b/packages/strapi-parts/src/Tooltip/utils/positionTooltip.js
@@ -54,7 +54,7 @@ const positionTop = (tooltipRect, toggleSourceRect) => {
   } else if (top < 0 && left > 0) {
     //if overflow top but not left
     //place tooltip below source element
-    top = toggleSourceRect.height + tooltipRect.height / 2 + SPACE_BETWEEN;
+    top = toggleSourceRect.top + toggleSourceRect.height + SPACE_BETWEEN;
   }
 
   return {


### PR DESCRIPTION
## What/why
Fixed bad calculations for top pos of tooltip when overflow top but not left or right
