### PR TITLE
Aspecific data attribute on FieldError and zIndex

### DIFF
--- a/packages/strapi-parts/src/Field/FieldError.js
+++ b/packages/strapi-parts/src/Field/FieldError.js
@@ -10,7 +10,7 @@ export const FieldError = () => {
   }
 
   return (
-    <P small={true} id={`${id}-error`} textColor="danger600">
+    <P small={true} id={`${id}-error`} textColor="danger600" data-strapi-field-error>
       {error}
     </P>
   );

--- a/packages/strapi-parts/src/ModalLayout/ModalLayout.js
+++ b/packages/strapi-parts/src/ModalLayout/ModalLayout.js
@@ -8,6 +8,7 @@ import { ModalContext } from './ModalContext';
 
 const ModalWrapper = styled.div`
   position: absolute;
+  z-index: 3;
   inset: 0;
   // this is theme.colors.neutral200 with opacity
   background: rgb(220, 220, 228, 0.8);

--- a/packages/strapi-parts/src/Tooltip/Tooltip.js
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.js
@@ -11,6 +11,8 @@ import { VisuallyHidden } from '../VisuallyHidden';
 
 const TooltipWrapper = styled(Box)`
   position: absolute;
+  /* z-index exist because of its position inside Modals */
+  z-index: 3;
   display: ${({ visible }) => (visible ? 'revert' : 'none')};
 `;
 

--- a/packages/strapi-parts/src/Tooltip/__tests__/Tooltip.spec.js
+++ b/packages/strapi-parts/src/Tooltip/__tests__/Tooltip.spec.js
@@ -34,6 +34,7 @@ describe('Tooltip', () => {
 
       .c1 {
         position: absolute;
+        z-index: 3;
         display: none;
       }
 
@@ -117,6 +118,7 @@ describe('Tooltip', () => {
 
       .c1 {
         position: absolute;
+        z-index: 3;
         display: revert;
       }
 
@@ -196,6 +198,7 @@ describe('Tooltip', () => {
 
       .c1 {
         position: absolute;
+        z-index: 3;
         display: revert;
       }
 

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -12281,6 +12281,7 @@ exports[`Storyshots Design System/Molecules/Checkbox error 1`] = `
       </label>
       <p
         class="c6"
+        data-strapi-field-error="true"
         id="checkbox-14-error"
       >
         Description line lorem ipsum
@@ -13813,6 +13814,7 @@ exports[`Storyshots Design System/Molecules/Field with error 1`] = `
       </div>
       <p
         class="c6"
+        data-strapi-field-error="true"
         id="field-18-error"
       >
         Password is too short
@@ -21360,6 +21362,7 @@ exports[`Storyshots Design System/Molecules/TextInput with error 1`] = `
           </div>
           <p
             class="c11"
+            data-strapi-field-error="true"
             id="textinput-147-error"
           >
             Content is too long
@@ -21581,6 +21584,7 @@ exports[`Storyshots Design System/Molecules/Textarea base 1`] = `
           />
           <p
             class="c8"
+            data-strapi-field-error="true"
             id="textarea-150-error"
           >
             Content is too short


### PR DESCRIPTION
- `data-strapi-field-error` exist to easily target the form element that is in error. For now, when using a "Select" component in core, it's not possible to focus it since our implementation of the `<Form>` component relies on the "name" HTML attribute that is not set on the `<button>` element
 
- set a zIndex on ModalLayout because it goes under the left main nav and subnav. Also put a zIndex on the Tooltip so that it can go over the ModalLayout (for the closing button)