### PR TITLE
Fix leak on observer not disconnecting

### DIFF
--- a/packages/strapi-parts/src/helpers/useElementOnScreen.js
+++ b/packages/strapi-parts/src/helpers/useElementOnScreen.js
@@ -9,11 +9,17 @@ export const useElementOnScreen = (options) => {
   };
 
   useEffect(() => {
+    const containerEl = containerRef.current;
     const observer = new IntersectionObserver(callback, options);
-    if (containerRef.current) observer.observe(containerRef.current);
+
+    if (containerEl) {
+      observer.observe(containerRef.current);
+    }
 
     return () => {
-      if (containerRef.current) observer.disconnect();
+      if (containerEl) {
+        observer.disconnect();
+      }
     };
   }, [containerRef, options]);
 


### PR DESCRIPTION
The observer was not disconnecting properly because the reference to the `.current` value does not exist anymore when cleaning the effect. The fix consists of capturing the `.current` variable

Before:

![2021-08-18 09 49 40](https://user-images.githubusercontent.com/3874873/129859733-19fb1359-2908-4b9a-8b30-58d4083062a1.gif)


After:

![2021-08-18 09 50 13](https://user-images.githubusercontent.com/3874873/129859802-4a994b4c-57cb-4eff-b4c6-ad6a17c9d171.gif)
