### PR TITLE
Th's icon size only forced in ActionWrapper

### DIFF
--- a/packages/strapi-parts/src/Table/Cell.js
+++ b/packages/strapi-parts/src/Table/Cell.js
@@ -18,7 +18,7 @@ const CellWrapper = styled(RawTd)`
   }
 `;
 
-const ActionWrapper = styled(CellWrapper)`
+const ActionWrapper = styled.span`
   svg {
     height: ${4 / 16}rem;
   }

--- a/packages/strapi-parts/src/Table/Cell.js
+++ b/packages/strapi-parts/src/Table/Cell.js
@@ -18,7 +18,7 @@ const CellWrapper = styled(RawTd)`
   }
 `;
 
-const ThWrapper = styled(CellWrapper)`
+const ActionWrapper = styled(CellWrapper)`
   svg {
     height: ${4 / 16}rem;
   }
@@ -26,12 +26,12 @@ const ThWrapper = styled(CellWrapper)`
 
 export const Th = ({ children, action, ...props }) => {
   return (
-    <ThWrapper as={RawTh} {...props}>
+    <CellWrapper as={RawTh} {...props}>
       <Row>
         {children}
-        {action}
+        <ActionWrapper>{action}</ActionWrapper>
       </Row>
-    </ThWrapper>
+    </CellWrapper>
   );
 };
 

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -6158,9 +6158,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                             tabindex="0"
                             type="checkbox"
                           />
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6177,9 +6176,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             ID
                           </span>
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6196,9 +6194,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Cover
                           </span>
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6215,9 +6212,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Description
                           </span>
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6234,9 +6230,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Categories
                           </span>
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6253,9 +6248,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Contact
                           </span>
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6268,9 +6262,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           class="c1 c18"
                         >
                           More
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6283,9 +6276,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           class="c1 c18"
                         >
                           More
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6298,9 +6290,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           class="c1 c18"
                         >
                           More
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -6317,9 +6308,8 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Actions
                           </div>
-                          <td
-                            class="c61 c63"
-                            tabindex="-1"
+                          <span
+                            class="c63"
                           />
                         </div>
                       </th>
@@ -25815,9 +25805,8 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                       tabindex="0"
                       type="checkbox"
                     />
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -25834,9 +25823,8 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                     >
                       ID
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -25853,9 +25841,8 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                     >
                       Cover
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -25872,9 +25859,8 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                     >
                       Description
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -25891,9 +25877,8 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                     >
                       Categories
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -25910,9 +25895,8 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                     >
                       Contact
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -25929,9 +25913,8 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                     >
                       Actions
                     </div>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -27059,9 +27042,8 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                       tabindex="0"
                       type="checkbox"
                     />
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -27077,8 +27059,8 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                     >
                       ID
                     </span>
-                    <td
-                      class="c10 c13"
+                    <span
+                      class="c13"
                     >
                       <span>
                         <button
@@ -27104,7 +27086,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                           </svg>
                         </button>
                       </span>
-                    </td>
+                    </span>
                   </div>
                 </th>
                 <th
@@ -27120,9 +27102,8 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                     >
                       Cover
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -27139,9 +27120,8 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                     >
                       Description
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -27158,9 +27138,8 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                     >
                       Categories
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -27177,9 +27156,8 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                     >
                       Contact
                     </span>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>
@@ -27196,9 +27174,8 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                     >
                       Actions
                     </div>
-                    <td
-                      class="c10 c13"
-                      tabindex="-1"
+                    <span
+                      class="c13"
                     />
                   </div>
                 </th>

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -4958,7 +4958,7 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
   pointer-events: none;
 }
 
-.c63 {
+.c62 {
   margin: 0;
   height: 18px;
   min-width: 18px;
@@ -4968,12 +4968,12 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
   background-color: #ffffff;
 }
 
-.c63:checked {
+.c62:checked {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c63:checked:after {
+.c62:checked:after {
   content: '';
   display: block;
   position: relative;
@@ -4987,21 +4987,21 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c63:checked:disabled:after {
+.c62:checked:disabled:after {
   background: url(test-file-stub) no-repeat no-repeat center center;
 }
 
-.c63:disabled {
+.c62:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c63:indeterminate {
+.c62:indeterminate {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c63:indeterminate:after {
+.c62:indeterminate:after {
   content: '';
   display: block;
   position: relative;
@@ -5016,12 +5016,12 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c63:indeterminate:disabled {
+.c62:indeterminate:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c63:indeterminate:disabled:after {
+.c62:indeterminate:disabled:after {
   background-color: #8e8ea9;
 }
 
@@ -5424,7 +5424,7 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
   vertical-align: sub;
 }
 
-.c62 svg {
+.c63 svg {
   height: 0.25rem;
 }
 
@@ -6147,22 +6147,26 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                     >
                       <th
                         aria-colindex="1"
-                        class="c61 c62"
+                        class="c61"
                       >
                         <div
                           class="c1 c18"
                         >
                           <input
                             aria-label="Select all entries"
-                            class="c63"
+                            class="c62"
                             tabindex="0"
                             type="checkbox"
+                          />
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
                           />
                         </div>
                       </th>
                       <th
                         aria-colindex="2"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
@@ -6173,11 +6177,15 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             ID
                           </span>
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                       <th
                         aria-colindex="3"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
@@ -6188,11 +6196,15 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Cover
                           </span>
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                       <th
                         aria-colindex="4"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
@@ -6203,11 +6215,15 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Description
                           </span>
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                       <th
                         aria-colindex="5"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
@@ -6218,11 +6234,15 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Categories
                           </span>
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                       <th
                         aria-colindex="6"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
@@ -6233,44 +6253,60 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Contact
                           </span>
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                       <th
                         aria-colindex="7"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
                           class="c1 c18"
                         >
                           More
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                       <th
                         aria-colindex="8"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
                           class="c1 c18"
                         >
                           More
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                       <th
                         aria-colindex="9"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
                           class="c1 c18"
                         >
                           More
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                       <th
                         aria-colindex="10"
-                        class="c61 c62"
+                        class="c61"
                         tabindex="-1"
                       >
                         <div
@@ -6281,6 +6317,10 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                           >
                             Actions
                           </div>
+                          <td
+                            class="c61 c63"
+                            tabindex="-1"
+                          />
                         </div>
                       </th>
                     </tr>
@@ -6298,7 +6338,7 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c63"
+                          class="c62"
                           tabindex="-1"
                           type="checkbox"
                         />
@@ -6469,7 +6509,7 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c63"
+                          class="c62"
                           tabindex="-1"
                           type="checkbox"
                         />
@@ -6640,7 +6680,7 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c63"
+                          class="c62"
                           tabindex="-1"
                           type="checkbox"
                         />
@@ -6811,7 +6851,7 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c63"
+                          class="c62"
                           tabindex="-1"
                           type="checkbox"
                         />
@@ -6982,7 +7022,7 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
                       >
                         <input
                           aria-label="Select Leon Lafrite"
-                          class="c63"
+                          class="c62"
                           tabindex="-1"
                           type="checkbox"
                         />
@@ -25472,7 +25512,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
   text-transform: uppercase;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25524,7 +25564,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
   pointer-events: none;
 }
 
-.c13 {
+.c12 {
   margin: 0;
   height: 18px;
   min-width: 18px;
@@ -25534,12 +25574,12 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
   background-color: #ffffff;
 }
 
-.c13:checked {
+.c12:checked {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c13:checked:after {
+.c12:checked:after {
   content: '';
   display: block;
   position: relative;
@@ -25553,21 +25593,21 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c13:checked:disabled:after {
+.c12:checked:disabled:after {
   background: url(test-file-stub) no-repeat no-repeat center center;
 }
 
-.c13:disabled {
+.c12:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c13:indeterminate {
+.c12:indeterminate {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c13:indeterminate:after {
+.c12:indeterminate:after {
   content: '';
   display: block;
   position: relative;
@@ -25582,12 +25622,12 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c13:indeterminate:disabled {
+.c12:indeterminate:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c13:indeterminate:disabled:after {
+.c12:indeterminate:disabled:after {
   background-color: #8e8ea9;
 }
 
@@ -25692,7 +25732,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
   vertical-align: sub;
 }
 
-.c11 svg {
+.c13 svg {
   height: 0.25rem;
 }
 
@@ -25764,107 +25804,135 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
               >
                 <th
                   aria-colindex="1"
-                  class="c10 c11"
+                  class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <input
                       aria-label="Select all entries"
-                      class="c13"
+                      class="c12"
                       tabindex="0"
                       type="checkbox"
+                    />
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
                     />
                   </div>
                 </th>
                 <th
                   aria-colindex="2"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       ID
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="3"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       Cover
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="4"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       Description
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="5"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       Categories
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="6"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       Contact
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="7"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <div
                       class="c0"
                     >
                       Actions
                     </div>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
               </tr>
@@ -25882,7 +25950,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -25955,7 +26023,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -26020,7 +26088,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -26093,7 +26161,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -26158,7 +26226,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -26231,7 +26299,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -26296,7 +26364,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -26369,7 +26437,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -26434,7 +26502,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -26507,7 +26575,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -26574,7 +26642,7 @@ exports[`Storyshots Design System/Organisms/Table base 1`] = `
           class="c25 c26"
         >
           <div
-            class="c12"
+            class="c11"
           >
             <div
               aria-hidden="true"
@@ -26688,7 +26756,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
   text-transform: uppercase;
 }
 
-.c12 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -26740,7 +26808,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
   pointer-events: none;
 }
 
-.c13 {
+.c12 {
   margin: 0;
   height: 18px;
   min-width: 18px;
@@ -26750,12 +26818,12 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
   background-color: #ffffff;
 }
 
-.c13:checked {
+.c12:checked {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c13:checked:after {
+.c12:checked:after {
   content: '';
   display: block;
   position: relative;
@@ -26769,21 +26837,21 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c13:checked:disabled:after {
+.c12:checked:disabled:after {
   background: url(test-file-stub) no-repeat no-repeat center center;
 }
 
-.c13:disabled {
+.c12:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c13:indeterminate {
+.c12:indeterminate {
   background-color: #4945ff;
   border: 1px solid #4945ff;
 }
 
-.c13:indeterminate:after {
+.c12:indeterminate:after {
   content: '';
   display: block;
   position: relative;
@@ -26798,12 +26866,12 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
   transform: translateX(-50%) translateY(-50%);
 }
 
-.c13:indeterminate:disabled {
+.c12:indeterminate:disabled {
   background-color: #dcdce4;
   border: 1px solid #c0c0cf;
 }
 
-.c13:indeterminate:disabled:after {
+.c12:indeterminate:disabled:after {
   background-color: #8e8ea9;
 }
 
@@ -26908,7 +26976,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
   vertical-align: sub;
 }
 
-.c11 svg {
+.c13 svg {
   height: 0.25rem;
 }
 
@@ -26980,130 +27048,158 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
               >
                 <th
                   aria-colindex="1"
-                  class="c10 c11"
+                  class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <input
                       aria-label="Select all entries"
-                      class="c13"
+                      class="c12"
                       tabindex="0"
                       type="checkbox"
+                    />
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
                     />
                   </div>
                 </th>
                 <th
                   aria-colindex="2"
-                  class="c10 c11"
+                  class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       ID
                     </span>
-                    <span>
-                      <button
-                        aria-disabled="false"
-                        aria-labelledby="tooltip-116"
-                        class="c17 c18"
-                        tabindex="-1"
-                        type="button"
-                      >
-                        <svg
-                          fill="none"
-                          height="1em"
-                          viewBox="0 0 14 8"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
+                    <td
+                      class="c10 c13"
+                    >
+                      <span>
+                        <button
+                          aria-disabled="false"
+                          aria-labelledby="tooltip-116"
+                          class="c17 c18"
+                          tabindex="-1"
+                          type="button"
                         >
-                          <path
-                            clip-rule="evenodd"
-                            d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
-                            fill="#32324D"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </button>
-                    </span>
+                          <svg
+                            fill="none"
+                            height="1em"
+                            viewBox="0 0 14 8"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              clip-rule="evenodd"
+                              d="M14 .889a.86.86 0 01-.26.625L7.615 7.736A.834.834 0 017 8a.834.834 0 01-.615-.264L.26 1.514A.861.861 0 010 .889c0-.24.087-.45.26-.625A.834.834 0 01.875 0h12.25c.237 0 .442.088.615.264a.86.86 0 01.26.625z"
+                              fill="#32324D"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </td>
                   </div>
                 </th>
                 <th
                   aria-colindex="3"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       Cover
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="4"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       Description
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="5"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       Categories
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="6"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
                       class="c14 c15 c16"
                     >
                       Contact
                     </span>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
                 <th
                   aria-colindex="7"
-                  class="c10 c11"
+                  class="c10"
                   tabindex="-1"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <div
                       class="c0"
                     >
                       Actions
                     </div>
+                    <td
+                      class="c10 c13"
+                      tabindex="-1"
+                    />
                   </div>
                 </th>
               </tr>
@@ -27121,7 +27217,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -27194,7 +27290,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -27259,7 +27355,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -27332,7 +27428,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -27397,7 +27493,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -27470,7 +27566,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -27535,7 +27631,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -27608,7 +27704,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -27673,7 +27769,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                 >
                   <input
                     aria-label="Select Leon Lafrite"
-                    class="c13"
+                    class="c12"
                     tabindex="-1"
                     type="checkbox"
                   />
@@ -27746,7 +27842,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
                   class="c10"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span>
                       <button
@@ -27813,7 +27909,7 @@ exports[`Storyshots Design System/Organisms/Table with th actions 1`] = `
           class="c25 c26"
         >
           <div
-            class="c12"
+            class="c11"
           >
             <div
               aria-hidden="true"


### PR DESCRIPTION
## What

height: ${4 / 16}rem => only for ActionWrapper 

## Why

To prevent every icon in Th to be forced to this size

## Demo
<img width="1131" alt="Capture d’écran 2021-08-18 à 15 16 24" src="https://user-images.githubusercontent.com/71838159/129904714-b3112b5c-9283-4b38-b4ad-9a0f886e1e3a.png">
