### PR TITLE
Docs - Tooltip & Timepicker

### DIFF
--- a/packages/strapi-parts/src/TimePicker/TimePicker.stories.mdx
+++ b/packages/strapi-parts/src/TimePicker/TimePicker.stories.mdx
@@ -20,7 +20,13 @@ Time pickers help users selecting a specific timeslot from a suggested timetable
 - One single format of time is currently available, which is a 24-hour one.
 - The Time picker is built on top on a Field component.
 
-## TimePicker
+## Imports
+
+```js
+import { TimePicker } from '@strapi/parts/TimePicker';
+```
+
+## Usage
 
 Use the Time picker component whenever a specific time needs to be scheduled or indicated. It is only possible to select one single timeslot.
 
@@ -45,7 +51,7 @@ Use the Time picker component whenever a specific time needs to be scheduled or 
   </Story>
 </Canvas>
 
-## TimePicker 30 mns steps
+### TimePicker 30 mns steps
 
 The unit of the Time Picker can be modified by changing the `step` parameter.
 

--- a/packages/strapi-parts/src/TimePicker/TimePicker.stories.mdx
+++ b/packages/strapi-parts/src/TimePicker/TimePicker.stories.mdx
@@ -2,17 +2,27 @@
 
 import { useState } from 'react';
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { ArgsTable } from '@storybook/addon-docs';
 import { TimePicker } from './TimePicker';
 
 <Meta title="Design System/Molecules/TimePicker" component={TimePicker} />
 
 # TimePicker
 
-This is the doc of the `TimePicker` component
+Time pickers help users selecting a specific timeslot from a suggested timetable. They can be associated to a Date picker component.
+
+**Best practices**
+
+- It is not possible to write a timeslot from the keyboard.
+- It is not possible to change the time format.
+- The PopOver closes after selecting a timeslot.
+- A Time picker can used simultaneously with a Date picker in a form.
+- One single format of time is currently available, which is a 24-hour one.
+- The Time picker is built on top on a Field component.
 
 ## TimePicker
 
-Description...
+Use the Time picker component whenever a specific time needs to be scheduled or indicated. It is only possible to select one single timeslot.
 
 <Canvas>
   <Story name="base">
@@ -37,7 +47,7 @@ Description...
 
 ## TimePicker 30 mns steps
 
-Description...
+The unit of the Time Picker can be modified by changing the `step` parameter.
 
 <Canvas>
   <Story name="30-mns-step">
@@ -60,3 +70,9 @@ Description...
     }}
   </Story>
 </Canvas>
+
+
+
+## Props
+
+<ArgsTable of={TimePicker} />

--- a/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
@@ -30,13 +30,14 @@ Tooltips are floating labels that display additional information upon hover of a
 import { Tooltip } from '@strapi/parts/Tooltip';
 ```
 
-## Tooltip
+## Usage
 
-Tooltips are used to show the full version of truncated text or is a way to display further information about an element. 
+Tooltips are used to show the full version of truncated text or is a way to display further information about an element.
+The tooltip will appear on top of adjacent text.
 
-<Canvas>
+<Canvas withSource="open">
   <Story name="base">
-    <div style={{ marginLeft: '400px', marginTop: '200px', width: '400px' }}>
+    <div>
       <p>
         An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
         elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -45,27 +46,6 @@ Tooltips are used to show the full version of truncated text or is a way to disp
         sunt in culpa qui officia deserunt mollit anim id est laborum.
       </p>
       <Tooltip description="Content of the tooltip">
-        <button>Show tooltip</button>
-      </Tooltip>
-      <p>
-        An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-        elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-        exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-        sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-    </div>
-  </Story>
-  <Story name="with text inside">
-    <div style={{ marginLeft: '400px', marginTop: '200px', width: '400px' }}>
-      <p>
-        An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-        elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-        exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-        sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-      <Tooltip description="Smaller">
         <span>Show tooltip</span>
       </Tooltip>
       <p>
@@ -75,132 +55,59 @@ Tooltips are used to show the full version of truncated text or is a way to disp
         voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
         sunt in culpa qui officia deserunt mollit anim id est laborum.
       </p>
-      <p>
-        An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-        elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-        exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-        sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-      <p>
-        An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-        elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-        exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-        sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-      <p>
-        An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-        elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-        exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-        sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
     </div>
   </Story>
+</Canvas>
+
+### Tooltip with smaller text or longer description
+
+Tootips work with longer texts as well.
+
+<Canvas withSource="open">
+  <Story name="with text inside">
+    <div>
+      <Tooltip description="Smaller">
+        <span>Show tooltip</span>
+      </Tooltip>
+    </div>
+    <div>
+      <Tooltip description="Excepteur sint occaecat cupidatat non proident, sunt
+        in culpa qui officia deserunt mollit anim id est laborum.">
+        <button>A longer CTA with longer content</button>
+      </Tooltip>
+    </div>
+  </Story>
+</Canvas>
+
+### Alternative positioning
+
+You can change the position of the tooltip by changing the `position` parameter.
+The default position is `top`.
+
+<Canvas withSource="open">
   <Story name="grid">
-    <p>
-      An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-      elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-      voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-      in culpa qui officia deserunt mollit anim id est laborum.
-    </p>
-    <p>
-      An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-      elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-      voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-      in culpa qui officia deserunt mollit anim id est laborum.
-    </p>
-    <p>
-      An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-      elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-      voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-      in culpa qui officia deserunt mollit anim id est laborum.
-    </p>
-    <p>
-      An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-      elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-      voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-      in culpa qui officia deserunt mollit anim id est laborum.
-    </p>
-    <Grid gap={4} padding={4} style={{ marginTop: '200px' }}>
-      <GridItem col={6}>
-        <Tooltip description="First content">
-          <button>First</button>
+    <Grid gap={4} padding={4}>
+      <GridItem col={3}>
+        <Tooltip description="Tootips are neat.">
+          <button>Default tooltip</button>
         </Tooltip>
       </GridItem>
-      <GridItem col={6}>
-        <Tooltip description="Second content" position="bottom">
-          <button>Second</button>
+      <GridItem col={3}>
+        <Tooltip description="Tootips are neat." position="bottom">
+          <button>Bottom</button>
         </Tooltip>
       </GridItem>
-      <GridItem col={6}>
-        <Tooltip description="Third content" position="right">
-          <button>Third</button>
+      <GridItem col={3}>
+        <Tooltip description="Tootips are neat." position="right">
+          <button>Right</button>
         </Tooltip>
       </GridItem>
-      <GridItem col={6}>
-        <Tooltip description="Fourth content" position="left">
-          <button>A longer CTA than the content</button>
+      <GridItem col={3}>
+        <Tooltip description="Tootips are neat." position="left">
+          <button>Left</button>
         </Tooltip>
       </GridItem>
     </Grid>
-    <p>
-      An infinite amount of content to place correctly the tooltip. Lorem ipsum dolor sit amet, consectetur adipiscing
-      elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-      voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-      in culpa qui officia deserunt mollit anim id est laborum.
-    </p>
-  </Story>
-  <Story name="description">
-    <Tooltip description="This is the description">
-      <button>This is a label with a description in the tooltip</button>
-    </Tooltip>
-  </Story>
-  <Story name="label">
-    <Tooltip label="This is the label">
-      <button>+</button>
-    </Tooltip>
-  </Story>
-  <Story name="top-left">
-    <div>
-      <Tooltip label="This is the label">
-        <button>hello</button>
-      </Tooltip>
-    </div>
-  </Story>
-  <Story name="top-center">
-    <Row justifyContent="center">
-      <Tooltip label="This is the label">
-        <button>hello</button>
-      </Tooltip>
-    </Row>
-  </Story>
-  <Story name="top-right">
-    <Row justifyContent="flex-end">
-      <Tooltip label="This is the label dewdewd wedewdew">
-        <button>tooltip</button>
-      </Tooltip>
-    </Row>
-  </Story>
-  <Story name="right-center">
-    <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '200px' }}>
-      <Tooltip label="This is the label">
-        <button>tooltip</button>
-      </Tooltip>
-    </div>
-  </Story>
-  <Story name="left-center">
-    <div style={{ marginTop: '200px' }}>
-      <Tooltip label="This is the label">
-        <button>hello</button>
-      </Tooltip>
-    </div>
   </Story>
 </Canvas>
 

--- a/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.stories.mdx
@@ -1,6 +1,7 @@
 <!--- Tooltip.stories.mdx --->
 
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { ArgsTable } from '@storybook/addon-docs';
 import { Tooltip } from './Tooltip';
 import { Box } from '../Box';
 import { Row } from '../Row';
@@ -10,11 +11,28 @@ import { Grid, GridItem } from '../Grid';
 
 # Tooltip
 
-This is the doc of the `Tooltip` component
+Tooltips are floating labels that display additional information upon hover of an element.
+
+**Best practices**
+
+- The tooltip should remain as long as the mouse is not moved.
+- The tooltip should provide additional useful details.
+- The tooltip should not be used to provide critical or urgent information.
+- Tooltip shouldn't be longer or wider than 400px.
+- Tooltips should be used sparingly.
+
+[View source](https://github.com/strapi/design-system-experiments/tree/develop/packages/strapi-parts/src/Tooltip)
+
+
+## Imports
+
+```js
+import { Tooltip } from '@strapi/parts/Tooltip';
+```
 
 ## Tooltip
 
-Description...
+Tooltips are used to show the full version of truncated text or is a way to display further information about an element. 
 
 <Canvas>
   <Story name="base">
@@ -185,3 +203,7 @@ Description...
     </div>
   </Story>
 </Canvas>
+
+## Props
+
+<ArgsTable of={Tooltip} />


### PR DESCRIPTION
# Tooltip & Time picker docs

## Description
Docs for the Tooltip and Time Picker components with props and imports

note: the tooltip `canvas` demo doesn't seems to work correctly though, there's a bunch of text. 

![Screenshot 2021-08-26 at 16 40 29](https://user-images.githubusercontent.com/4447713/130983433-64e718c2-6b85-459a-bf4a-891402e4fa8a.png)


Edit: here's my proposition for documenting the different properties.
I'm not sure the Smaller example actually displays the tooltip as smaller.
I'm propose to use real buttons to make it more obvious that you can have a cta.

![Screenshot 2021-08-27 at 19 03 49](https://user-images.githubusercontent.com/4447713/131163481-b2238124-f3be-480c-8393-f26ba178f62c.png)


## Demo
Example on :  See message below 👇

