### PR TITLE
Prevent header from triggering state modif when undefined

### DIFF
--- a/packages/strapi-parts/src/Layout/HeaderLayout.js
+++ b/packages/strapi-parts/src/Layout/HeaderLayout.js
@@ -17,7 +17,11 @@ const useHeaderSize = () => {
     threshold: 0,
   });
 
-  useResizeObserver(containerRef, () => setHeaderSize(containerRef.current.getBoundingClientRect()));
+  useResizeObserver(containerRef, () => {
+    if (containerRef.current) {
+      setHeaderSize(containerRef.current.getBoundingClientRect());
+    }
+  });
 
   useEffect(() => {
     if (baseHeaderLayoutRef.current) {


### PR DESCRIPTION
# [title]

## Description
[add description]

## Demo
Example on : [deployed story link]

## API
[api details]

```jsx
<YourComponent />
```

## Voiceover

[voiceover gif]