### PR TITLE
Add dev build

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lerna": "^4.0.0",
     "lint-staged": ">=10",
     "plop": "^2.7.4",
+    "rimraf": "^3.0.2",
     "url-loader": "^4.1.1"
   },
   "husky": {

--- a/packages/strapi-parts/createIndexFiles.js
+++ b/packages/strapi-parts/createIndexFiles.js
@@ -1,0 +1,30 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+const excludedFolders = ['helpers', '.DS_Store'];
+const fileNames = fs.readdirSync(path.resolve(__dirname, 'src'));
+
+const entries = fileNames.filter((name) => !excludedFolders.includes(name));
+
+const createIndexFile = async (fileName) => {
+  const name = fileName.replace('.js', '');
+  const content = `
+  'use strict';
+  
+  if (process.env.NODE_ENV === "production") {
+    module.exports = require("./${name}.production.js");
+  } else {
+    module.exports = require("./${name}.development.js");
+  }
+  `;
+
+  try {
+    fs.writeFile(path.resolve(__dirname, 'dist', `${name}.js`), content);
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+entries.forEach((entry) => {
+  createIndexFile(entry);
+});

--- a/packages/strapi-parts/package.json
+++ b/packages/strapi-parts/package.json
@@ -53,7 +53,12 @@
   },
   "scripts": {
     "analyze:bundle": "cross-env BUNDLE_ANALYZE=1 webpack",
-    "build": "webpack &&  node ../../tools/copy-files.js",
+    "prebuild": "rimraf dist",
+    "build": "yarn build:dev && yarn build:prod && yarn copy:files && yarn create:index-files",
+    "build:dev": "cross-env NODE_ENV=development webpack-cli",
+    "build:prod": "cross-env NODE_ENV=production webpack-cli",
+    "copy:files": "node ../../tools/copy-files.js",
+    "create:index-files": "node ./createIndexFiles.js",
     "build-storybook": "build-storybook",
     "lint": "eslint . --ext .js,.jsx --fix",
     "lint-staged": "eslint --fix",

--- a/packages/strapi-parts/webpack.config.js
+++ b/packages/strapi-parts/webpack.config.js
@@ -1,12 +1,11 @@
 const fs = require('fs');
 const path = require('path');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 // Allows to create distinct bundles in the dist folder
 // for people wanting to import only specific components such as
 // import Button from '@strapi/parts/Button
-const excludedFolders = ['helpers'];
+const excludedFolders = ['helpers', '.DS_Store'];
 const fileNames = fs.readdirSync(path.resolve(__dirname, 'src'));
 const entry = fileNames
   .filter((name) => !excludedFolders.includes(name))
@@ -30,14 +29,14 @@ if (process.env.BUNDLE_ANALYZE) {
 
 module.exports = {
   entry,
-  mode: 'production',
-  // FIXME remove when DS ready
-  devtool: 'eval-source-map',
+  mode: process.env.NODE_ENV,
+  devtool: process.env.NODE_ENV === 'development' ? 'eval-source-map' : false,
   output: {
-    filename: '[name].js',
+    filename: `[name].${process.env.NODE_ENV}.js`,
     path: path.resolve(__dirname, 'dist'),
     libraryTarget: 'umd',
     library: 'strapiDs',
+    umdNamedDefine: true,
   },
   module: {
     rules: [
@@ -61,7 +60,7 @@ module.exports = {
       },
     ],
   },
-  plugins: [new CleanWebpackPlugin()].concat(analyzePlugins),
+  plugins: [].concat(analyzePlugins),
   externals: [
     {
       react: 'react',


### PR DESCRIPTION
Signed-off-by: soupette <cyril@strapi.io>

# Add development build

## Description
This PR builds the lib in both development environment and production. It allows us to display errors in the console especially with the prop-types.

## Demo
Example on : [deployed story link]

## API
[api details]

```jsx
<YourComponent />
```

## Voiceover

[voiceover gif]