### PR TITLE
Binding main and h1, implicitly

### DIFF
--- a/packages/strapi-parts/src/Main/Main.js
+++ b/packages/strapi-parts/src/Main/Main.js
@@ -7,9 +7,15 @@ const MainWrapper = styled.main`
 `;
 
 export const Main = ({ labelledBy, ...props }) => {
-  return <MainWrapper aria-labelledby={labelledBy} id="main-content" tabIndex={-1} {...props} />;
+  const ariaLabelledBy = labelledBy || 'main-content-title';
+
+  return <MainWrapper aria-labelledby={ariaLabelledBy} id="main-content" tabIndex={-1} {...props} />;
+};
+
+Main.defaultProps = {
+  labelledBy: undefined,
 };
 
 Main.propTypes = {
-  labelledBy: PropTypes.string.isRequired,
+  labelledBy: PropTypes.string,
 };

--- a/packages/strapi-parts/src/Text/H1.js
+++ b/packages/strapi-parts/src/Text/H1.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { ellipsisStyle, handleColor } from './utils';
+
+const StyledH1 = styled.h1`
+  font-weight: 600;
+  font-size: ${32 / 16}rem;
+  line-height: 1.25;
+  color: ${handleColor};
+  ${ellipsisStyle}
+`;
+
+export const H1 = ({ as, ...props }) => {
+  let id;
+
+  if (as === 'h1') {
+    id = 'main-content-title';
+  }
+
+  return <StyledH1 id={id} as={as} {...props} />;
+};
+
+H1.defaultProps = {
+  as: 'h1',
+};
+
+H1.propTypes = {
+  as: PropTypes.string,
+};

--- a/packages/strapi-parts/src/Text/index.js
+++ b/packages/strapi-parts/src/Text/index.js
@@ -1,23 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-
-const handleColor = ({ theme, textColor }) => theme.colors[textColor || 'neutral800'];
-const ellipsisStyle = ({ ellipsis }) =>
-  ellipsis &&
-  `
-    display: inline-block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  `;
-
-export const H1 = styled.h1`
-  font-weight: 600;
-  font-size: ${32 / 16}rem;
-  line-height: 1.25;
-  color: ${handleColor};
-  ${ellipsisStyle}
-`;
+import { ellipsisStyle, handleColor } from './utils';
 
 export const H2 = styled.h2`
   font-weight: 600;
@@ -79,3 +62,5 @@ export const EllipsisText = styled(Text)`
   overflow: hidden;
   text-overflow: ellipsis;
 `;
+
+export * from './H1';

--- a/packages/strapi-parts/src/Text/utils.js
+++ b/packages/strapi-parts/src/Text/utils.js
@@ -1,0 +1,10 @@
+export const ellipsisStyle = ({ ellipsis }) =>
+  ellipsis &&
+  `
+    display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  `;
+
+export const handleColor = ({ theme, textColor }) => theme.colors[textColor || 'neutral800'];


### PR DESCRIPTION
Make main labelled by the default H1 id. main label and H1 id can both be overriden if necessary

Instead of:

```jsx
<Main labelledBy="title">
  <H1 id="title"></H1>
</Main>
```

just do

```jsx
<Main>
  <H1></H1>
</Main>
```