### PR TITLE
Fix tooltip props

### DIFF
--- a/packages/strapi-parts/src/Tooltip/Tooltip.js
+++ b/packages/strapi-parts/src/Tooltip/Tooltip.js
@@ -65,7 +65,7 @@ Tooltip.defaultProps = {
 Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   delay: PropTypes.number,
-  description: PropTypes.string,
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   id: PropTypes.string,
   label: PropTypes.string,
   position: PropTypes.oneOf(['top', 'left', 'bottom', 'right']),


### PR DESCRIPTION
Signed-off-by: soupette <cyril@strapi.io>

# [title]

## Description
[add description]

## Demo
Example on : [deployed story link]

## API
[api details]

```jsx
<YourComponent />
```

## Voiceover

[voiceover gif]