### PR TITLE
Allowing IconButton to not receive a label

### DIFF
--- a/packages/strapi-parts/src/IconButton/IconButton.js
+++ b/packages/strapi-parts/src/IconButton/IconButton.js
@@ -95,6 +95,14 @@ export const IconButton = React.forwardRef(({ label, noBorder, icon, disabled, o
     }
   };
 
+  if (!label) {
+    return (
+      <IconButtonWrapper {...props} ref={ref} noBorder={noBorder} onClick={handleClick} aria-disabled={disabled}>
+        {icon}
+      </IconButtonWrapper>
+    );
+  }
+
   return (
     <Tooltip label={label}>
       <IconButtonWrapper {...props} ref={ref} noBorder={noBorder} onClick={handleClick} aria-disabled={disabled}>
@@ -107,9 +115,8 @@ export const IconButton = React.forwardRef(({ label, noBorder, icon, disabled, o
 IconButton.displayName = 'IconButton';
 
 IconButton.defaultProps = {
-  title: undefined,
-  noBorder: false,
   label: undefined,
+  noBorder: false,
   disabled: false,
   onClick: undefined,
 };

--- a/packages/strapi-parts/src/IconButton/IconButton.stories.mdx
+++ b/packages/strapi-parts/src/IconButton/IconButton.stories.mdx
@@ -74,7 +74,7 @@ Depending on the status of an action or the permissions, an IconButton can be un
 
 ### IconButton Disabled
 
-An Icon button without the tooltip. It can be intersting to rely on this component to avoid showing a tooltip when focusing the modals close button. **However, when not using a label, the developer should add an explicit aria-label to the button.**
+An Icon button without the tooltip. It can be interesting to rely on this component to avoid showing a tooltip when focusing the modals close button. **However, when not using a label, the developer should add an explicit aria-label to the button.**
 
 <Canvas>
   <Story name="without tooltip">

--- a/packages/strapi-parts/src/IconButton/IconButton.stories.mdx
+++ b/packages/strapi-parts/src/IconButton/IconButton.stories.mdx
@@ -17,7 +17,8 @@ import { Row } from '../Row';
 Icon Buttons are a way to perform actions within a page, a table or another object. They help interact with its content via a single click in small page portion. According to their minimal style, they help understand the most important actions to take.
 
 **Best practices**
->>>>>>> develop
+
+> > > > > > > develop
 
 - Icon Buttons do not have labels.
 - A Tooltip should be displayed at hover.
@@ -25,7 +26,7 @@ Icon Buttons are a way to perform actions within a page, a table or another obje
 - Icon Buttons can be displayed next to each others whenever the actions are distinct.
 - In Table component, avoid using a border.
 - The icon chosen to represent the action should be perfectly explicit.
-[View source](https://github.com/strapi/parts/tree/develop/packages/strapi-parts/src/IconButton)
+  [View source](https://github.com/strapi/parts/tree/develop/packages/strapi-parts/src/IconButton)
 
 ## Imports
 
@@ -36,7 +37,6 @@ import PublishIcon from '@strapi/icons/PublishIcon';
 import DeleteIcon from '@strapi/icons/DeleteIcon';
 import AddIcon from '@strapi/icons/AddIcon';
 ```
-
 
 ## Usage
 
@@ -72,6 +72,18 @@ Depending on the status of an action or the permissions, an IconButton can be un
   </Story>
 </Canvas>
 
+### IconButton Disabled
+
+An Icon button without the tooltip. It can be interested to rely on this component to avoid showing a tooltip when focusing the modals close button. **However, when not using a label, the developer should add an explicit aria-label to the button.**
+
+<Canvas>
+  <Story name="without tooltip">
+    <Box padding={7}>
+      <IconButton onClick={() => console.log('edit')} aria-label="Edit" icon={<EditIcon />} />
+    </Box>
+  </Story>
+</Canvas>
+
 ### IconButtonGroup
 
 IconButtons can be used within another component is a Group shape.
@@ -88,7 +100,6 @@ IconButtons can be used within another component is a Group shape.
     </Box>
   </Story>
 </Canvas>
-
 
 ## Props
 

--- a/packages/strapi-parts/src/IconButton/IconButton.stories.mdx
+++ b/packages/strapi-parts/src/IconButton/IconButton.stories.mdx
@@ -74,7 +74,7 @@ Depending on the status of an action or the permissions, an IconButton can be un
 
 ### IconButton Disabled
 
-An Icon button without the tooltip. It can be interested to rely on this component to avoid showing a tooltip when focusing the modals close button. **However, when not using a label, the developer should add an explicit aria-label to the button.**
+An Icon button without the tooltip. It can be intersting to rely on this component to avoid showing a tooltip when focusing the modals close button. **However, when not using a label, the developer should add an explicit aria-label to the button.**
 
 <Canvas>
   <Story name="without tooltip">

--- a/packages/strapi-parts/src/ModalLayout/ModalHeader.js
+++ b/packages/strapi-parts/src/ModalLayout/ModalHeader.js
@@ -18,7 +18,7 @@ export const ModalHeader = ({ children, closeLabel }) => {
     <ModalHeaderWrapper paddingTop={4} paddingBottom={4} paddingLeft={5} paddingRight={5} background="neutral100">
       <Row justifyContent="space-between">
         {children}
-        <IconButton onClick={onClose} label={closeLabel} icon={<CloseAlertIcon />} />
+        <IconButton onClick={onClose} aria-label={closeLabel} icon={<CloseAlertIcon />} />
       </Row>
     </ModalHeaderWrapper>
   );

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -16075,6 +16075,108 @@ exports[`Storyshots Design System/Molecules/IconButton group 1`] = `
 </main>
 `;
 
+exports[`Storyshots Design System/Molecules/IconButton without tooltip 1`] = `
+.c0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c1 {
+  padding: 32px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  background: #ffffff;
+  border: 1px solid #dcdce4;
+}
+
+.c2 svg {
+  height: 12px;
+  width: 12px;
+}
+
+.c2 svg > g,
+.c2 svg path {
+  fill: #ffffff;
+}
+
+.c2[aria-disabled='true'] {
+  pointer-events: none;
+}
+
+.c3 svg > g,
+.c3 svg path {
+  fill: #8e8ea9;
+}
+
+.c3:hover svg > g,
+.c3:hover svg path {
+  fill: #666687;
+}
+
+.c3:active svg > g,
+.c3:active svg path {
+  fill: #a5a5ba;
+}
+
+.c3[aria-disabled='true'] {
+  background-color: #eaeaef;
+}
+
+.c3[aria-disabled='true'] svg path {
+  fill: #666687;
+}
+
+<main>
+  <div
+    class="c0"
+  >
+    <h1>
+      Storybook story
+    </h1>
+  </div>
+  <div
+    class="c1"
+  >
+    <button
+      aria-disabled="false"
+      aria-label="Edit"
+      class="c2 c3"
+      type="button"
+    >
+      <svg
+        fill="none"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M23.604 3.514c.528.528.528 1.36 0 1.887l-2.622 2.607-4.99-4.99L18.6.396a1.322 1.322 0 011.887 0l3.118 3.118zM0 24v-4.99l14.2-14.2 4.99 4.99L4.99 24H0z"
+          fill="#212134"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </button>
+  </div>
+</main>
+`;
+
 exports[`Storyshots Design System/Molecules/Link base 1`] = `
 .c0 {
   border: 0;


### PR DESCRIPTION
Allow an IconButton to not receive a label. This aims to prevent the closing button inside a modal to display the tooltip.

However, developers, when not relying on the label prop, should add an explicit `aria-label`