### PR TITLE
Fix header layout console error

### DIFF
--- a/packages/strapi-parts/src/Layout/HeaderLayout.js
+++ b/packages/strapi-parts/src/Layout/HeaderLayout.js
@@ -42,9 +42,9 @@ export const HeaderLayout = (props) => {
 
   return (
     <>
-      <Box style={{ height: headerSize?.height }} ref={containerRef}>
+      <div style={{ height: headerSize?.height }} ref={containerRef}>
         {isVisible && <BaseHeaderLayout ref={baseHeaderLayoutRef} {...props} />}
-      </Box>
+      </div>
       {!isVisible && <BaseHeaderLayout {...props} sticky width={headerSize?.width} />}
     </>
   );

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -4434,7 +4434,6 @@ exports[`Storyshots Design System/Layouts/HeaderLayout combined w/ scroll 1`] = 
     style="height: 2000px;"
   >
     <div
-      class="c1 "
       style="height: 0px;"
     >
       <div
@@ -6368,7 +6367,6 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
         class="c1 c39 c40"
       >
         <div
-          class="c1 "
           style="height: 0px;"
         >
           <div


### PR DESCRIPTION
Biggest fix of all time preventing Box from yelling because children is not undefined