### PR TITLE
Subnav badge fix

### DIFF
--- a/example/src/shared/Wysiwyg/_test_/Wysiwyg.spec.js
+++ b/example/src/shared/Wysiwyg/_test_/Wysiwyg.spec.js
@@ -41,7 +41,7 @@ describe("Wysiwyg render and actions buttons", () => {
     expect(getContainerByText("hello world")).toBeInTheDocument();
     expect(renderedContainer.firstChild).toMatchInlineSnapshot(`
       <span
-        class="sc-jVSGNQ sc-QxirK bSkxym ldCiYB"
+        class="sc-gJryWy sc-fFYUIl dZlOus ivRTtQ"
       >
         hello world
       </span>

--- a/packages/strapi-parts/src/SubNav/SubNavSection.js
+++ b/packages/strapi-parts/src/SubNav/SubNavSection.js
@@ -19,8 +19,6 @@ const SubNavSectionWrapper = styled(Box)`
 const SubNavSectionBadge = styled(Badge)`
   display: flex;
   align-items: center;
-  height: ${20 / 16}rem;
-  width: ${16 / 16}rem;
 `;
 
 export const SubNavSection = ({ collapsable, label, badgeLabel, children, id }) => {

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -5749,8 +5749,6 @@ exports[`Storyshots Design System/Layouts/Layout base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  height: 1.25rem;
-  width: 1rem;
 }
 
 .c3 {
@@ -30429,8 +30427,6 @@ exports[`Storyshots Design System/Organisms/SubNav base 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  height: 1.25rem;
-  width: 1rem;
 }
 
 .c33 {


### PR DESCRIPTION
## What

Fixed subnav badge size

## Demo 

From:
<img width="276" alt="Capture d’écran 2021-09-21 à 14 34 45" src="https://user-images.githubusercontent.com/71838159/134171838-20817b93-78f6-42ba-be96-f4c88ee7a716.png">

To: 
<img width="309" alt="Capture d’écran 2021-09-21 à 14 34 54" src="https://user-images.githubusercontent.com/71838159/134171867-568cbbf6-7f25-4423-af86-ce2624422d4c.png">
 