### PR TITLE
Checkbox align start

### DIFF
--- a/packages/strapi-parts/src/Checkbox/Checkbox.js
+++ b/packages/strapi-parts/src/Checkbox/Checkbox.js
@@ -10,7 +10,7 @@ import { Text } from '../Text';
 
 const CheckboxLabel = styled(Text)`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   * {
     cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'default')};
   }

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -14244,10 +14244,10 @@ exports[`Storyshots Design System/Molecules/Checkbox base 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c3 * {
@@ -14401,10 +14401,10 @@ exports[`Storyshots Design System/Molecules/Checkbox disabled 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c3 * {
@@ -14567,10 +14567,10 @@ exports[`Storyshots Design System/Molecules/Checkbox error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c3 * {
@@ -14739,10 +14739,10 @@ exports[`Storyshots Design System/Molecules/Checkbox hint 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c3 * {
@@ -14903,10 +14903,10 @@ exports[`Storyshots Design System/Molecules/Checkbox indeterminate 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c3 * {


### PR DESCRIPTION
For Multiline checkbox, the checkmark is now stick to the top of the label instead of at the center