### PR TITLE
Table border radius

### DIFF
--- a/packages/strapi-parts/src/Table/Table.js
+++ b/packages/strapi-parts/src/Table/Table.js
@@ -11,7 +11,8 @@ const TableWrapper = styled(RawTable)`
 
 const TableBox = styled(Box)`
   position: relative;
-  border-radius: ${({ theme }) => theme.borderRadius} ${({ theme }) => theme.borderRadius} 0 0;
+  border-radius: ${({ theme, footer }) =>
+    footer ? `${theme.borderRadius} ${theme.borderRadius} 0 0` : theme.borderRadius};
 
   &:before {
     // TODO: make sure to add a token for this weird stuff
@@ -46,6 +47,7 @@ const ScrollContainer = styled(Box)`
 export const Table = ({ colCount, rowCount, footer, ...props }) => {
   const tableRef = useRef(null);
   const [overflowing, setOverflowing] = useState();
+  console.log(footer);
 
   const handleScroll = (e) => {
     const maxScrollLeft = e.target.scrollWidth - e.target.clientWidth;
@@ -70,8 +72,8 @@ export const Table = ({ colCount, rowCount, footer, ...props }) => {
   }, []);
 
   return (
-    <Box shadow="tableShadow">
-      <TableBox background="neutral0" overflowing={overflowing}>
+    <Box shadow="tableShadow" hasRadius>
+      <TableBox footer={footer} background="neutral0" overflowing={overflowing}>
         <ScrollContainer ref={tableRef} onScroll={handleScroll} paddingLeft={6} paddingRight={6}>
           <TableWrapper colCount={colCount} rowCount={rowCount} {...props} />
         </ScrollContainer>

--- a/packages/strapi-parts/src/Table/Table.js
+++ b/packages/strapi-parts/src/Table/Table.js
@@ -13,6 +13,7 @@ const TableBox = styled(Box)`
   position: relative;
   border-radius: ${({ theme, footer }) =>
     footer ? `${theme.borderRadius} ${theme.borderRadius} 0 0` : theme.borderRadius};
+  overflow: hidden;
 
   &:before {
     // TODO: make sure to add a token for this weird stuff

--- a/packages/strapi-parts/src/Table/Table.js
+++ b/packages/strapi-parts/src/Table/Table.js
@@ -11,8 +11,8 @@ const TableWrapper = styled(RawTable)`
 
 const TableBox = styled(Box)`
   position: relative;
-  border-radius: ${({ theme, footer }) =>
-    footer ? `${theme.borderRadius} ${theme.borderRadius} 0 0` : theme.borderRadius};
+  border-radius: ${({ theme, withoutFullBorderRadius }) =>
+    withoutFullBorderRadius ? `${theme.borderRadius} ${theme.borderRadius} 0 0` : theme.borderRadius};
   overflow: hidden;
 
   &:before {
@@ -73,7 +73,7 @@ export const Table = ({ colCount, rowCount, footer, ...props }) => {
 
   return (
     <Box shadow="tableShadow" hasRadius>
-      <TableBox footer={footer} background="neutral0" overflowing={overflowing}>
+      <TableBox withoutFullBorderRadius={footer} background="neutral0" overflowing={overflowing}>
         <ScrollContainer ref={tableRef} onScroll={handleScroll} paddingLeft={6} paddingRight={6}>
           <TableWrapper colCount={colCount} rowCount={rowCount} {...props} />
         </ScrollContainer>

--- a/packages/strapi-parts/src/Table/Table.js
+++ b/packages/strapi-parts/src/Table/Table.js
@@ -48,7 +48,6 @@ const ScrollContainer = styled(Box)`
 export const Table = ({ colCount, rowCount, footer, ...props }) => {
   const tableRef = useRef(null);
   const [overflowing, setOverflowing] = useState();
-  console.log(footer);
 
   const handleScroll = (e) => {
     const maxScrollLeft = e.target.scrollWidth - e.target.clientWidth;

--- a/packages/strapi-parts/src/Table/Table.stories.mdx
+++ b/packages/strapi-parts/src/Table/Table.stories.mdx
@@ -176,11 +176,7 @@ Table with actions.
       }
       return (
         <Box padding={8} background="neutral100">
-          <Table
-            colCount={COL_COUNT}
-            rowCount={ROW_COUNT}
-            footer={<TFooter icon={<AddIcon />}>Add another field to this collection type</TFooter>}
-          >
+          <Table colCount={COL_COUNT} rowCount={ROW_COUNT}>
             <Thead>
               <Tr>
                 <Th>

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -13871,6 +13871,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 }
 
 .c62 {
+  border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -29299,6 +29300,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
 }
 
 .c2 {
+  border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -30588,6 +30590,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
 }
 
 .c2 {
+  border-radius: 4px;
   box-shadow: 0px 1px 4px rgba(33,33,52,0.1);
 }
 
@@ -30604,35 +30607,11 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
   padding-left: 4px;
 }
 
-.c23 {
-  background: #eaeaef;
-}
-
-.c25 {
-  background: #f0f0ff;
-  padding: 20px;
-}
-
-.c27 {
-  background: #d9d8ff;
-}
-
-.c29 {
-  padding-left: 12px;
-}
-
 .c14 {
   font-weight: 400;
   font-size: 0.875rem;
   line-height: 1.43;
   color: #32324d;
-}
-
-.c30 {
-  font-weight: 500;
-  font-size: 0.75rem;
-  line-height: 1.33;
-  color: #4945ff;
 }
 
 .c15 {
@@ -30839,12 +30818,6 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
   fill: #666687;
 }
 
-.c24 {
-  height: 1px;
-  border: none;
-  margin: 0;
-}
-
 .c7 {
   width: 100%;
   white-space: nowrap;
@@ -30852,7 +30825,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
 
 .c4 {
   position: relative;
-  border-radius: 4px 4px 0 0;
+  border-radius: 4px;
 }
 
 .c4:before {
@@ -30921,40 +30894,6 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
 
 .c13 svg {
   height: 0.25rem;
-}
-
-.c28 {
-  height: 1.5rem;
-  width: 1.5rem;
-  border-radius: 50%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c28 svg {
-  height: 0.625rem;
-  width: 0.625rem;
-}
-
-.c28 svg path {
-  fill: #4945ff;
-}
-
-.c26 {
-  border-radius: 0 0 4px 4px;
-  display: block;
-  width: 100%;
-  border: none;
 }
 
 <main>
@@ -31837,45 +31776,6 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
             </tbody>
           </table>
         </div>
-      </div>
-      <div>
-        <hr
-          class="c23 c24"
-        />
-        <button
-          class="c25 c26"
-        >
-          <div
-            class="c11"
-          >
-            <div
-              aria-hidden="true"
-              class="c27 c28"
-            >
-              <svg
-                fill="none"
-                height="1em"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M24 13.604a.3.3 0 01-.3.3h-9.795V23.7a.3.3 0 01-.3.3h-3.21a.3.3 0 01-.3-.3v-9.795H.3a.3.3 0 01-.3-.3v-3.21a.3.3 0 01.3-.3h9.795V.3a.3.3 0 01.3-.3h3.21a.3.3 0 01.3.3v9.795H23.7a.3.3 0 01.3.3v3.21z"
-                  fill="#212134"
-                />
-              </svg>
-            </div>
-            <div
-              class="c29"
-            >
-              <span
-                class="c30"
-              >
-                Add another field to this collection type
-              </span>
-            </div>
-          </div>
-        </button>
       </div>
     </div>
   </div>

--- a/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
+++ b/packages/strapi-parts/tests/__snapshots__/storyshots.spec.js.snap
@@ -14638,6 +14638,7 @@ exports[`Storyshots Design System/Components/Layout base 1`] = `
 .c64 {
   position: relative;
   border-radius: 4px 4px 0 0;
+  overflow: hidden;
 }
 
 .c64:before {
@@ -29566,6 +29567,7 @@ exports[`Storyshots Design System/Components/Table base 1`] = `
 .c4 {
   position: relative;
   border-radius: 4px 4px 0 0;
+  overflow: hidden;
 }
 
 .c4:before {
@@ -30826,6 +30828,7 @@ exports[`Storyshots Design System/Components/Table with th actions 1`] = `
 .c4 {
   position: relative;
   border-radius: 4px;
+  overflow: hidden;
 }
 
 .c4:before {


### PR DESCRIPTION
## What

Fixed border-radius for table => table should always have 4px border-radius all around
- If footer then footer deals with bottom border-radius if not table handles it
- Added hasRadius to main table container to prevent weird borders overflowing
- Overflow hidden on TableBox to prevent shadows to overflow border-radius


## Screenshots 

<img width="783" alt="Capture d’écran 2021-10-05 à 16 14 09" src="https://user-images.githubusercontent.com/71838159/136040677-16a6a38f-5233-4ac6-b3b3-645b3187e851.png">

<img width="783" alt="Capture d’écran 2021-10-05 à 16 14 16" src="https://user-images.githubusercontent.com/71838159/136040683-118d2ff1-9466-4f3d-86be-437a97499b17.png">

<img width="610" alt="Capture d’écran 2021-10-05 à 16 12 01" src="https://user-images.githubusercontent.com/71838159/136040524-dc88f84a-5a35-489e-aa20-7de49a312660.png">


